### PR TITLE
Added support for multiple output formats

### DIFF
--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -114,6 +114,20 @@ def diagonal_asy(F, r=None, linear_form=None, return_points=False, output_format
         [(4, 1/sqrt(n), 1/sqrt(pi), 1)]
         sage: acsv_logger.setLevel(logging.WARNING)
 
+
+    Tests:
+
+    Check that passing a non-supported ``output_format`` errors out::
+
+        sage: diagonal_asy(1/(1 - x - y), output_format='hello world')
+        Traceback (most recent call last):
+        ...
+        ValueError: 'hello world' is not a valid OutputFormat
+        sage: diagonal_asy(1/(1 - x - y), output_format=42)
+        Traceback (most recent call last):
+        ...
+        ValueError: 42 is not a valid OutputFormat
+
     """
     G, H = F.numerator(), F.denominator()
     if r is None:

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -1,4 +1,20 @@
+from enum import Enum
+
 from sage.all import QQ, ceil, gcd, matrix, randint
+
+
+class OutputFormat(Enum):
+    """Output options for displaying the asymptotic behavior determined
+    by :func:`.diagonal_asy`.
+
+    See also:
+
+    - :func:`.diagonal_asy`
+    """
+    ASYMPTOTIC = "asymptotic"
+    SYMBOLIC = "symbolic"
+    TUPLE = "tuple"
+    
 
 
 def RationalFunctionReduce(G, H):


### PR DESCRIPTION
This implements a new keyword argument, `output_format` of `diagonal_asy` which allows to specify one of multiple supported output types (among them: as an asymptotic expansion via `output_format="asymptotic"`.

As `output_format` is more general than the previous `as_symbolic` kwarg, I've deprecated (but not removed) `as_symbolic`.