### PR TITLE
chore: update CI to test package with sagelib 10.0 and up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sagelib: "9.6"
-          - sagelib: "9.7"
-          - sagelib: "9.8"
           - sagelib: "10.0"
+          - sagelib: "10.1"
+          - sagelib: "10.2"
+          - sagelib: "10.3"
+          - sagelib: "10.4"
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
           - sagelib: "10.3"
           - sagelib: "10.4"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with: { submodules: recursive }
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true }
       - name: Install dependencies
         shell: bash -l {0}


### PR DESCRIPTION
The tests in the CI pipeline should primarily test the more recent versions of SageMath, this removes the tests for 9.6 etc, and only tests from 10.0 onwards.