### PR TITLE
Cleanup in `asymptotic` module

### DIFF
--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -132,7 +132,7 @@ def _diagonal_asy_smooth(
             break
         except Exception as e:
             if isinstance(e, ACSVException) and e.retry:
-                acsv_logger.warning(
+                acsv_logger.info(
                     "Randomly generated linear form was not suitable, "
                     f"encountered error: {e}\nRetrying..."
                 )
@@ -952,10 +952,7 @@ def ContributingCombinatorial(
         [[3/4, 3/2]]
 
     """
-
-    #####
     timer = Timer()
-
     (
         expanded_R,
         vs,

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -50,18 +50,20 @@ def _diagonal_asy_smooth(
     INPUT:
 
     * ``G`` -- The numerator of the rational function ``F``.
-    * ``H`` -- The numerator of the rational function ``F``.
-    * ``r`` -- A vector of length d of positive algebraic numbers (generally integers).
-      Defaults to the appropriate vector of all 1's if not specified.
+    * ``H`` -- The denominator of the rational function ``F``.
+    * ``r`` -- A vector of positive algebraic numbers (generally integers),
+      one entry per variable of `F`. Defaults to the appropriate vector of
+      all 1's if not specified.
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions.
-    * ``expansion_precision`` -- A positive integer value. This is the number of terms to
-      compute in the asymptotic expansion. Defaults to 1, which only computes the leading
-      term.
+    * ``expansion_precision`` -- A positive integer value. This is the number
+      of terms to compute in the asymptotic expansion. Defaults to 1, which
+      only computes the leading term.
     * ``return_points`` -- If ``True``, also returns the coordinates of
       minimal critical points. By default ``False``.
-    * ``output_format`` -- (Optional) A string or :class:`.ACSVSettings.Output` specifying
-      the way the asymptotic growth is returned. Allowed values currently are:
+    * ``output_format`` -- (Optional) A string or :class:`.ACSVSettings.Output`
+      specifying the way the asymptotic growth is returned. Allowed values
+      currently are:
       - ``"tuple"``: the growth is returned as a list of
         tuples of the form ``(a, n^b, pi^c, d)`` such that the `r`-diagonal of `F`
         is the sum of ``a^n n^b pi^c d + O(a^n n^{b-1})`` over these tuples.
@@ -69,16 +71,17 @@ def _diagonal_asy_smooth(
         ring ``SR`` in the variable ``n``.
       - ``"asymptotic"``: the growth is returned as an expression from an appropriate
         ``AsymptoticRing`` in the variable ``n``.
-      - ``None``: the default, which uses the default set for :class:`.ACSVSettings.Output`
-        itself via :meth:`.ACSVSettings.set_default_output_format`. The default behavior
+      - ``None``: the default, which uses the default set for
+        :class:`.ACSVSettings.Output` itself via 
+        :meth:`.ACSVSettings.set_default_output_format`. The default behavior
         is asymptotic output.
     * ``as_symbolic`` -- deprecated in favor of the equivalent
       ``output_format="symbolic"``. Will be removed in a future release.
 
     OUTPUT:
 
-    A representation of the asymptotic main term, either as a list of tuples,
-    or as a symbolic expression.
+    A representation of the asymptotic behavior of the coefficient sequence,
+    either as a list of tuples, or as a symbolic expression.
 
     See also:
 
@@ -229,44 +232,49 @@ def diagonal_asy(
     whitney_strat=None,
     as_symbolic=False
 ):
-    r"""Asymptotics in a given direction `r` of the multivariate rational function `F`.
+    r"""Asymptotic behavior of the coefficient array of a multivariate rational
+    function `F` along a given direction `r`.
 
     INPUT:
 
-    * ``F`` -- The rational function ``G/H`` in ``d`` variables. This function is
+    * ``F`` -- The rational function `G/H` in `d` variables. This function is
       assumed to have a combinatorial expansion.
-    * ``r`` -- A vector of length d of positive algebraic numbers (generally integers).
+    * ``r`` -- A vector of length `d` of positive algebraic numbers.
       Defaults to the appropriate vector of all 1's if not specified.
     * ``linear_form`` -- (Optional) A linear combination of the input
-      variables that separates the critical point solutions.
-    * ``expansion_precision`` -- A positive integer value. This is the number of terms to
-      compute in the asymptotic expansion. Defaults to 1, which only computes the leading
-      term.
+      variables that separates the critical point solutions. Is generated
+      randomly if not specified.
+    * ``expansion_precision`` -- A positive integer, the number of terms to
+      compute in the asymptotic expansion. Defaults to 1, which only computes
+      the leading term.
     * ``return_points`` -- If ``True``, also returns the coordinates of
       minimal critical points. By default ``False``.
-    * ``output_format`` -- (Optional) A string or :class:`.ACSVSettings.Output` specifying
-      the way the asymptotic growth is returned. Allowed values currently are:
+    * ``output_format`` -- (Optional) A string or
+      :class:`.ACSVSettings.Output` specifying the way the asymptotic growth
+      is returned. Allowed values currently are:
       - ``"tuple"``: the growth is returned as a list of
         tuples of the form ``(a, n^b, pi^c, d)`` such that the `r`-diagonal of `F`
-        is the sum of ``a^n n^b pi^c d + O(a^n n^{b-1})`` over these tuples.
+        behaves like the sum of ``a^n n^b pi^c d + O(a^n n^{b-1})`` over these tuples.
       - ``"symbolic"``: the growth is returned as an expression from the symbolic
         ring ``SR`` in the variable ``n``.
       - ``"asymptotic"``: the growth is returned as an expression from an appropriate
         ``AsymptoticRing`` in the variable ``n``.
-      - ``None``: the default, which uses the default set for :class:`.ACSVSettings.Output`
-        itself via :meth:`.ACSVSettings.set_default_output_format`. The default behavior
-        is symbolic output.
+      - ``None``: the default, which uses the default set for
+        :class:`.ACSVSettings.Output` itself via
+        :meth:`.ACSVSettings.set_default_output_format`. The default behavior
+        is asymptotic output.
     * ``as_symbolic`` -- deprecated in favor of the equivalent
       ``output_format="symbolic"``. Will be removed in a future release.
-    * ``whitney_strat`` -- (Optional) The user can pass in a Whitney Stratification of V(H)
-        to save computation time. The program will not check if this stratification is correct.
-        The whitney_strat should be an array of length ``d``, with the ``k``-th entry a list of
-        tuples of ideal generators representing a component of the ``k``-dimensional stratum.
+    * ``whitney_strat`` -- (Optional) If known / precomputed, a 
+      Whitney Stratification of `V(H)`. The program will not check if
+      this stratification is correct. Should be a list of length ``d``, where
+      the ``k``-th entry is a list of tuples of ideas generators representing
+      a component of the ``k``-dimensional stratum.
 
     OUTPUT:
 
-    A representation of the asymptotic main term, either as a list of tuples,
-    or as a symbolic expression.
+    A representation of the asymptotic behavior of the coefficient array of `F` along
+    the specified direction.
 
     NOTE:
 
@@ -749,8 +757,8 @@ def GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision):
 
 def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
     r"""Compute contributing points of a combinatorial multivariate
-    rational function F=G/H admitting a finite number of critical points.
-    Assumes the singular variety of F is smooth.
+    rational function `F=G/H` admitting a finite number of critical points.
+    Assumes the singular variety of `F` is smooth.
 
     Typically, this function is called as a subroutine of :func:`._diagonal_asy_smooth`.
 
@@ -903,7 +911,7 @@ def _find_contributing_points_combinatorial(
     whitney_strat=None,
 ):
     r"""Compute contributing points of a combinatorial multivariate
-    rational function F=G/H admitting a finite number of critical points.
+    rational function `F=G/H` admitting a finite number of critical points.
 
     Typically, this function is called as a subroutine of :func:`.diagonal_asy`.
 
@@ -916,14 +924,15 @@ def _find_contributing_points_combinatorial(
       variables that separates the critical point solutions
     * ``m2`` -- (Optional) The option to pass in a SageMath Macaulay2 interface for
         computing primary decompositions. Macaulay2 must be installed by the user
-    * ``whitney_strat`` -- (Optional) The user can pass in a Whitney Stratification of V(H)
-        to save computation time. The program will not check if this stratification is correct.
-        The whitney_strat should be an array of length ``d``, with the ``k``-th entry a list of
-        tuples of ideal generators representing a component of the ``k``-dimensional stratum.
+    * ``whitney_strat`` -- (Optional) If known / precomputed, a 
+      Whitney Stratification of `V(H)`. The program will not check if
+      this stratification is correct. Should be a list of length ``d``, where
+      the ``k``-th entry is a list of tuples of ideas generators representing
+      a component of the ``k``-dimensional stratum.
 
     OUTPUT:
 
-    A list of minimal contributing points of `F` in the direction `r`,
+    A list of minimal contributing points of `F` in the direction `r`.
 
     NOTE:
 
@@ -1099,14 +1108,15 @@ def ContributingCombinatorial(
       variables that separates the critical point solutions
     * ``m2`` -- (Optional) The option to pass in a SageMath Macaulay2 interface for
         computing primary decompositions. Macaulay2 must be installed by the user
-    * ``whitney_strat`` -- (Optional) The user can pass in a Whitney Stratification of V(H)
-        to save computation time. The program will not check if this stratification is correct.
-        The whitney_strat should be an array of length ``d``, with the ``k``-th entry a list of
-        tuples of ideal generators representing a component of the ``k``-dimensional stratum.
+    * ``whitney_strat`` -- (Optional) If known / precomputed, a 
+      Whitney Stratification of `V(H)`. The program will not check if
+      this stratification is correct. Should be a list of length ``d``, where
+      the ``k``-th entry is a list of tuples of ideas generators representing
+      a component of the ``k``-dimensional stratum.
 
     OUTPUT:
 
-    A list of minimal contributing points of `F` in the direction `r`,
+    A list of minimal contributing points of `F` in the direction `r`.
 
     NOTE:
 
@@ -1151,27 +1161,25 @@ def ContributingCombinatorial(
 
 def MinimalCriticalCombinatorial(F, r=None, linear_form=None, m2=None, whitney_strat=None):
     r"""Compute nonzero minimal critical points of a combinatorial multivariate
-    rational function F=G/H admitting a finite number of critical points.
-
-    Typically, this function is called as a subroutine of :func:`.diagonal_asy`.
+    rational function `F=G/H` admitting a finite number of critical points.
 
     INPUT:
 
-    * ``G, H`` -- Coprime polynomials with ``F = G/H``
-    * ``variables`` -- List of variables of ``G`` and ``H``
+    * ``F`` -- Symbolic fraction, the rational function of interest.
     * ``r`` -- (Optional) Length ``d`` vector of positive integers
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions
     * ``m2`` -- (Optional) The option to pass in a SageMath Macaulay2 interface for
         computing primary decompositions. Macaulay2 must be installed by the user
-    * ``whitney_strat`` -- (Optional) The user can pass in a Whitney Stratification of V(H)
-        to save computation time. The program will not check if this stratification is correct.
-        The whitney_strat should be an array of length ``d``, with the ``k``-th entry a list of
-        tuples of ideal generators representing a component of the ``k``-dimensional stratum.
+    * ``whitney_strat`` -- (Optional) If known / precomputed, a 
+      Whitney Stratification of `V(H)`. The program will not check if
+      this stratification is correct. Should be a list of length ``d``, where
+      the ``k``-th entry is a list of tuples of ideas generators representing
+      a component of the ``k``-dimensional stratum.
 
     OUTPUT:
 
-    A list of minimal contributing points of `F` in the direction `r`,
+    A list of minimal contributing points of `F` in the direction `r`.
 
     NOTE:
 
@@ -1316,17 +1324,17 @@ def CriticalPoints(F, r=None, linear_form=None, m2=None, whitney_strat=None):
 
     INPUT:
 
-    * ``G, H`` -- Coprime polynomials with ``F = G/H``
-    * ``variables`` -- List of variables of ``G`` and ``H``
+    * ``F`` -- Symbolic fraction, the rational function of interest.
     * ``r`` -- (Optional) Length ``d`` vector of positive integers
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions
     * ``m2`` -- (Optional) The option to pass in a SageMath Macaulay2 interface for
         computing primary decompositions. Macaulay2 must be installed by the user
-    * ``whitney_strat`` -- (Optional) The user can pass in a Whitney Stratification of V(H)
-        to save computation time. The program will not check if this stratification is correct.
-        The whitney_strat should be an array of length ``d``, with the ``k``-th entry a list of
-        tuples of ideal generators representing a component of the ``k``-dimensional stratum.
+    * ``whitney_strat`` -- (Optional) If known / precomputed, a 
+      Whitney Stratification of `V(H)`. The program will not check if
+      this stratification is correct. Should be a list of length ``d``, where
+      the ``k``-th entry is a list of tuples of ideas generators representing
+      a component of the ``k``-dimensional stratum.
 
     OUTPUT:
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -32,7 +32,7 @@ asy_misc.strip_symbolic = strip_symbolic
 
 
 
-def diagonal_asy_smooth(
+def _diagonal_asy_smooth(
     F,
     r=None,
     linear_form=None,
@@ -77,130 +77,28 @@ def diagonal_asy_smooth(
     A representation of the asymptotic main term, either as a list of tuples,
     or as a symbolic expression.
 
-    NOTE:
+    See also:
 
-    The code randomly generates a linear form, which for generic rational functions
-    separates the solutions of an intermediate polynomial system with high probability.
-    This separation step can fail, but (assuming `F` has a finite number of critical
-    points) the code can be rerun until a separating form is found.
+    - :func:`.diagonal_asy`
 
-    Examples::
-
-        sage: from sage_acsv import diagonal_asy_smooth
-        sage: var('x,y,z,w')
-        (x, y, z, w)
-        sage: diagonal_asy_smooth(1/(1-x-y))
-        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
-        sage: diagonal_asy_smooth(1/(1-(1+x)*y), r = [1,2], return_points=True)
-        (1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2)), [[1, 1/2]])
-        sage: diagonal_asy_smooth(1/(1-(x+y+z)+(3/4)*x*y*z), output_format="symbolic")
-        0.840484893481498?*24.68093482214177?^n/(pi*n)
-        sage: diagonal_asy_smooth(1/(1-(x+y+z)+(3/4)*x*y*z))
-        0.840484893481498?/pi*24.68093482214177?^n*n^(-1) + O(24.68093482214177?^n*n^(-2))
-        sage: var('n')
-        n
-        sage: asy = diagonal_asy_smooth(
-        ....:     1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1)),
-        ....:     output_format="tuple",
-        ....: )
-        sage: sum([
-        ....:      a.radical_expression()^n * b * c * QQbar(d).radical_expression()
-        ....:      for (a, b, c, d) in asy
-        ....: ])
-        1/4*(12*sqrt(2) + 17)^n*sqrt(17/2*sqrt(2) + 12)/(pi^(3/2)*n^(3/2))
-
-    Not specifying any ``output_format`` falls back to the default tuple
-    representation::
-
-        sage: from sage_acsv import diagonal_asy_smooth
-        sage: var('x')
-        x
-        sage: diagonal_asy_smooth(1/(1 - 2*x))
-        2^n + O(2^n*n^(-1))
-        sage: diagonal_asy_smooth(1/(1 - 2*x), output_format="tuple")
-        [(2, 1, 1, 1)]
-
-    Passing ``"symbolic"`` lets the function return an element of the
-    symbolic ring in the variable ``n`` that describes the asymptotic growth::
-
-        sage: growth = diagonal_asy_smooth(1/(1 - 2*x), output_format="symbolic"); growth
-        2^n
-        sage: growth.parent()
-        Symbolic Ring
-
-    The argument ``"asymptotic"`` constructs an asymptotic expansion over
-    an appropriate ``AsymptoticRing`` in the variable ``n``, including the
-    appropriate error term::
-
-        sage: assume(SR.an_element() > 0)  # required to make coercions involving SR work properly
-        sage: growth = diagonal_asy_smooth(1/(1 - x - y), output_format="asymptotic"); growth
-        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
-        sage: growth.parent()
-        Asymptotic Ring <(Algebraic Real Field)^n * n^QQ * (Arg_(Algebraic Field))^n> over Symbolic Ring
-
-    Increasing the precision of the expansion returns an expansion with more terms
-    (works for all available output formats)::
-
-        sage: diagonal_asy_smooth(1/(1 - x - y), expansion_precision=3, output_format="asymptotic")
-        1/sqrt(pi)*4^n*n^(-1/2) - 1/8/sqrt(pi)*4^n*n^(-3/2) + 1/128/sqrt(pi)*4^n*n^(-5/2)
-        + O(4^n*n^(-7/2))
-
-    The direction of the diagonal, `r`, defaults to the standard diagonal (i.e., the
-    vector of all 1's) if not specified. It also supports passing non-integer values,
-    notably rational numbers::
-
-        sage: diagonal_asy_smooth(1/(1 - x - y), r=(1, 17/42), output_format="symbolic")
-        1.317305628032865?*2.324541507270374?^n/(sqrt(pi)*sqrt(n))
-    
-    and even algebraic numbers (note, however, that the performance for complicated
-    algebraic numbers is significantly degraded)::
-
-        sage: diagonal_asy_smooth(1/(1 - x - y), r=(sqrt(2), 1))
-        0.9238795325112868?/sqrt(pi)*(2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-1/2) + O((2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-3/2))
-
-    ::
-
-        sage: diagonal_asy_smooth(1/(1 - x - y*x^2), r=(1, 1/2 - 1/2*sqrt(1/5)), output_format="asymptotic")
-        1.710862642974252?/sqrt(pi)*1.618033988749895?^n*n^(-1/2)
-        + O(1.618033988749895?^n*n^(-3/2))
-
-    The function times individual steps of the algorithm, timings can
-    be displayed by increasing the printed verbosity level of our debug logger::
-
-        sage: import logging
-        sage: from sage_acsv.debug import acsv_logger
-        sage: acsv_logger.setLevel(logging.INFO)
-        sage: diagonal_asy_smooth(1/(1 - x - y))
-        INFO:sage_acsv:... Executed Kronecker in ... seconds.
-        INFO:sage_acsv:... Executed Minimal Points in ... seconds.
-        INFO:sage_acsv:... Executed Final Asymptotics in ... seconds.
-        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
-        sage: acsv_logger.setLevel(logging.WARNING)
-
-
-    Tests:
+    TESTS:
 
     Check that passing a non-supported ``output_format`` errors out::
 
-        sage: diagonal_asy_smooth(1/(1 - x - y), output_format='hello world')
+        sage: from sage_acsv import diagonal_asy
+        sage: var('x y')
+        (x, y)
+        sage: diagonal_asy(1/(1 - x - y), output_format='hello world')  # indirect doctest
         Traceback (most recent call last):
         ...
         ValueError: 'hello world' is not a valid OutputFormat
-        sage: diagonal_asy_smooth(1/(1 - x - y), output_format=42)
+        sage: diagonal_asy(1/(1 - x - y), output_format=42)  # indirect doctest
         Traceback (most recent call last):
         ...
         ValueError: 42 is not a valid OutputFormat
 
     """
     G, H = F.numerator(), F.denominator()
-    if r is None:
-        n = len(H.variables())
-        r = [1 for _ in range(n)]
-
-    try:
-        r = [QQ(ri) for ri in r]
-    except (ValueError, TypeError):
-        r = [AA(ri) for ri in r]
 
     # Initialize variables
     vs = list(H.variables())
@@ -378,17 +276,102 @@ def diagonal_asy(
     This separation step can fail, but (assuming `F` has a finite number of critical
     points) the code can be rerun until a separating form is found.
 
-    Examples::
+    EXAMPLES:
 
         sage: from sage_acsv import diagonal_asy
-        sage: var('x,y')
-        (x, y)
+        sage: var('x,y,z,w')
+        (x, y, z, w)
+        sage: diagonal_asy(1/(1-x-y))
+        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
+        sage: diagonal_asy(1/(1-(1+x)*y), r = [1,2], return_points=True)
+        (1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2)), [[1, 1/2]])
+        sage: diagonal_asy(1/(1-(x+y+z)+(3/4)*x*y*z), output_format="symbolic")
+        0.840484893481498?*24.68093482214177?^n/(pi*n)
+        sage: diagonal_asy(1/(1-(x+y+z)+(3/4)*x*y*z))
+        0.840484893481498?/pi*24.68093482214177?^n*n^(-1) + O(24.68093482214177?^n*n^(-2))
+        sage: var('n')
+        n
+        sage: asy = diagonal_asy(
+        ....:     1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1)),
+        ....:     output_format="tuple",
+        ....: )
+        sage: sum([
+        ....:      a.radical_expression()^n * b * c * QQbar(d).radical_expression()
+        ....:      for (a, b, c, d) in asy
+        ....: ])
+        1/4*(12*sqrt(2) + 17)^n*sqrt(17/2*sqrt(2) + 12)/(pi^(3/2)*n^(3/2))
+
+    Not specifying any ``output_format`` falls back to the default asymptotic
+    representation::
+
+        sage: diagonal_asy(1/(1 - 2*x))
+        2^n + O(2^n*n^(-1))
+        sage: diagonal_asy(1/(1 - 2*x), output_format="tuple")
+        [(2, 1, 1, 1)]
+
+    Passing ``"symbolic"`` lets the function return an element of the
+    symbolic ring in the variable ``n`` that describes the asymptotic growth::
+
+        sage: growth = diagonal_asy(1/(1 - 2*x), output_format="symbolic"); growth
+        2^n
+        sage: growth.parent()
+        Symbolic Ring
+
+    The argument ``"asymptotic"`` constructs an asymptotic expansion over
+    an appropriate ``AsymptoticRing`` in the variable ``n``, including the
+    appropriate error term::
+
+        sage: assume(SR.an_element() > 0)  # required to make coercions involving SR work properly
+        sage: growth = diagonal_asy(1/(1 - x - y), output_format="asymptotic"); growth
+        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
+        sage: growth.parent()
+        Asymptotic Ring <(Algebraic Real Field)^n * n^QQ * (Arg_(Algebraic Field))^n> over Symbolic Ring
+
+    Increasing the precision of the expansion returns an expansion with more terms
+    (works for all available output formats)::
+
+        sage: diagonal_asy(1/(1 - x - y), expansion_precision=3, output_format="asymptotic")
+        1/sqrt(pi)*4^n*n^(-1/2) - 1/8/sqrt(pi)*4^n*n^(-3/2) + 1/128/sqrt(pi)*4^n*n^(-5/2)
+        + O(4^n*n^(-7/2))
+
+    The direction of the diagonal, `r`, defaults to the standard diagonal (i.e., the
+    vector of all 1's) if not specified. It also supports passing non-integer values,
+    notably rational numbers::
+
+        sage: diagonal_asy(1/(1 - x - y), r=(1, 17/42), output_format="symbolic")
+        1.317305628032865?*2.324541507270374?^n/(sqrt(pi)*sqrt(n))
+    
+    and even algebraic numbers (note, however, that the performance for complicated
+    algebraic numbers is significantly degraded)::
+
+        sage: diagonal_asy(1/(1 - x - y), r=(sqrt(2), 1))
+        0.9238795325112868?/sqrt(pi)*(2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-1/2) + O((2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-3/2))
+
+    ::
+
+        sage: diagonal_asy(1/(1 - x - y*x^2), r=(1, 1/2 - 1/2*sqrt(1/5)), output_format="asymptotic")
+        1.710862642974252?/sqrt(pi)*1.618033988749895?^n*n^(-1/2)
+        + O(1.618033988749895?^n*n^(-3/2))
+
+    The function times individual steps of the algorithm, timings can
+    be displayed by increasing the printed verbosity level of our debug logger::
+
+        sage: import logging
+        sage: from sage_acsv import ACSVSettings
+        sage: ACSVSettings.set_logging_level(logging.INFO)
+        sage: diagonal_asy(1/(1 - x - y))
+        INFO:sage_acsv:... Executed Kronecker in ... seconds.
+        INFO:sage_acsv:... Executed Minimal Points in ... seconds.
+        INFO:sage_acsv:... Executed Final Asymptotics in ... seconds.
+        1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
+        sage: ACSVSettings.set_logging_level(logging.WARNING)
+    
+    Extraction of coefficient asymptotics even works in cases where the singular variety of `F`
+    is not smooth::
+        
         sage: diagonal_asy(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
         12 + O(n^(-1))
 
-        sage: from sage_acsv import diagonal_asy
-        sage: var('x,y,z')
-        (x, y, z)
         sage: diagonal_asy(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
         12 + O(n^(-1))
         sage: G = (1+x)*(1-x*y^2+x^2)
@@ -438,19 +421,6 @@ def diagonal_asy(
     if linear_form is not None:
         linear_form = SR(linear_form).subs(var_subs)
 
-    R = PolynomialRing(QQ, vs, len(vs))
-    H_sing = Ideal([R(H)] + [R(H.derivative(v)) for v in vs])
-    if H_sing.dimension() < 0:
-        return diagonal_asy_smooth(
-            F,
-            r = r,
-            linear_form = linear_form,
-            expansion_precision=expansion_precision,
-            return_points = return_points,
-            output_format = output_format,
-            as_symbolic=as_symbolic
-        )
-
     if r is None:
         n = len(H.variables())
         r = [1 for _ in range(n)]
@@ -459,6 +429,19 @@ def diagonal_asy(
         r = [QQ(ri) for ri in r]
     except (ValueError, TypeError):
         r = [AA(ri) for ri in r]
+
+    R = PolynomialRing(QQ, vs, len(vs))
+    H_sing = Ideal([R(H)] + [R(H.derivative(v)) for v in vs])
+    if H_sing.dimension() < 0:
+        return _diagonal_asy_smooth(
+            F,
+            r = r,
+            linear_form = linear_form,
+            expansion_precision=expansion_precision,
+            return_points = return_points,
+            output_format = output_format,
+            as_symbolic=as_symbolic
+        )
 
     t, lambda_, u_ = PolynomialRing(QQ, 't, lambda_, u_').gens()
     expanded_R = PolynomialRing(QQ, len(vs)+3, vs + [t, lambda_, u_])
@@ -584,7 +567,7 @@ def diagonal_asy(
         else:
             # Higher order expansions not currently supported for non-smooth critical points
             if expansion_precision > 1:
-                acsv_logger.warn("Higher order expansions are not supported in the non-smooth case. Defaulting to expansion_precision 1.")
+                acsv_logger.warning("Higher order expansions are not supported in the non-smooth case. Defaulting to expansion_precision 1.")
             # For non-complete intersections, we must compute the parametrized Hessian matrix
             if s != d:
                 Qw = ImplicitHessian(factors, vs, r, subs=subs_dict)
@@ -778,7 +761,7 @@ def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
     rational function F=G/H admitting a finite number of critical points.
     Assumes the singular variety of F is smooth.
 
-    Typically, this function is called as a subroutine of :func:`.diagonal_asy_smooth`.
+    Typically, this function is called as a subroutine of :func:`._diagonal_asy_smooth`.
 
     INPUT:
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -110,7 +110,6 @@ def _diagonal_asy_smooth(
     t, lambda_, u_ = expanded_R(t), expanded_R(lambda_), expanded_R(u_)
     vsT = vs + [t, lambda_]
 
-    all_variables = (vs, lambda_, t, u_)
     d = len(vs)
     rd = r[-1]
     vd = vs[-1]
@@ -126,7 +125,7 @@ def _diagonal_asy_smooth(
         try:
             # Find minimal critical points in Kronecker Representation
             min_crit_pts = ContributingCombinatorialSmooth(
-                G, H, all_variables,
+                G, H, vs,
                 r=r,
                 linear_form=linear_form
             )
@@ -449,7 +448,6 @@ def diagonal_asy(
     vs = [expanded_R(v) for v in vs]
     t, lambda_, u_ = expanded_R(t), expanded_R(lambda_), expanded_R(u_)
 
-    all_variables = (vs, lambda_, t, u_)
     d = len(vs)
 
     # Make sure G and H are coprime, and that H does not vanish at 0
@@ -464,7 +462,7 @@ def diagonal_asy(
         try:
             # Find minimal critical points in Kronecker Representation
             min_crit_pts = ContributingCombinatorial(
-                G, H_sf, all_variables,
+                G, H_sf, vs,
                 r=r,
                 linear_form=linear_form,
                 whitney_strat=whitney_strat
@@ -766,8 +764,7 @@ def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
     INPUT:
 
     * ``G, H`` -- Coprime polynomials with `F = G/H`.
-    * ``variables`` -- Tuple of variables of ``G`` and ``H``, followed
-      by ``lambda_, t, u_``.
+    * ``variables`` -- List of variables of ``G`` and ``H``.
     * ``r`` -- (Optional) the direction, a vector of positive algebraic
       numbers (usually integers).
     * ``linear_form`` -- (Optional) A linear combination of the input
@@ -792,22 +789,20 @@ def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
         sage: pts = ContributingCombinatorialSmooth(
         ....:     1,
         ....:     1 - w*(y + x + x^2*y + x*y^2),
-        ....:     ([w, x, y], lambda_, t, u_)
+        ....:     [w, x, y],
         ....: )
         sage: sorted(pts)
         [[-1/4, -1, -1], [1/4, 1, 1]]
     """
 
     timer = Timer()
-    
-    vs, _, _, _ = variables
     (
         expanded_R,
         vs,
         (t, lambda_, u_),
         r,
         r_variable_values,
-    ) = _prepare_expanded_polynomial_ring(vs, direction=r)
+    ) = _prepare_expanded_polynomial_ring(variables, direction=r)
 
     G, H = expanded_R(G), expanded_R(H)
     vsT = vs + list(r_variable_values.keys()) + [t, lambda_]
@@ -922,8 +917,7 @@ def ContributingCombinatorial(
     INPUT:
 
     * ``G, H`` -- Coprime polynomials with ``F = G/H``
-    * ``variables`` -- Tuple of variables of ``G`` and ``H``, followed
-      by ``lambda_, t, u_``
+    * ``variables`` -- List of variables of ``G`` and ``H``
     * ``r`` -- (Optional) Length ``d`` vector of positive integers
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions
@@ -952,7 +946,7 @@ def ContributingCombinatorial(
         sage: pts = ContributingCombinatorial(
         ....:     1,
         ....:     (1-(2*x+y)/3)*(1-(3*x+y)/4),
-        ....:     ([x, y], lambda_, t, u_)
+        ....:     [x, y],
         ....: )
         sage: sorted(pts)
         [[3/4, 3/2]]
@@ -962,16 +956,14 @@ def ContributingCombinatorial(
     #####
     timer = Timer()
 
-    vs, _, _, _ = variables
     (
         expanded_R,
         vs,
         (t, lambda_, u_),
         r,
         r_variable_values,
-    ) = _prepare_expanded_polynomial_ring(vs, direction=r)
-
-    G, H = expanded_R(G), expanded_R(H)
+    ) = _prepare_expanded_polynomial_ring(variables, direction=r)
+    H = expanded_R(H)
     vsT = vs + list(r_variable_values.keys()) + [t, lambda_]
 
     # Compute the critical point system for each stratum
@@ -1120,8 +1112,7 @@ def MinimalCriticalCombinatorial(G, H, variables, r=None, linear_form=None, m2=N
     INPUT:
 
     * ``G, H`` -- Coprime polynomials with ``F = G/H``
-    * ``variables`` -- Tuple of variables of ``G`` and ``H``, followed
-      by ``lambda_, t, u_``
+    * ``variables`` -- List of variables of ``G`` and ``H``
     * ``r`` -- (Optional) Length ``d`` vector of positive integers
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions
@@ -1150,20 +1141,19 @@ def MinimalCriticalCombinatorial(G, H, variables, r=None, linear_form=None, m2=N
         sage: pts = MinimalCriticalCombinatorial(
         ....:     1,
         ....:     (1-(2*x+y)/3)*(1-(3*x+y)/4),
-        ....:     ([x, y], lambda_, t, u_)
+        ....:     [x, y],
         ....: )
         sage: sorted(pts)
         [[3/4, 3/2], [1, 1]]
 
     """
-    vs, _, _, _ = variables
     (
         expanded_R,
         vs,
         (t, lambda_, u_),
         r,
         r_variable_values,
-    ) = _prepare_expanded_polynomial_ring(vs, direction=r)
+    ) = _prepare_expanded_polynomial_ring(variables, direction=r)
     H = expanded_R(H)
 
     vsT = vs + list(r_variable_values) + [t, lambda_]
@@ -1272,8 +1262,7 @@ def CriticalPoints(G, H, variables, r=None, linear_form=None, m2=None, whitney_s
     INPUT:
 
     * ``G, H`` -- Coprime polynomials with ``F = G/H``
-    * ``variables`` -- Tuple of variables of ``G`` and ``H``, followed
-      by ``t`` and ``u_``
+    * ``variables`` -- List of variables of ``G`` and ``H``
     * ``r`` -- (Optional) Length ``d`` vector of positive integers
     * ``linear_form`` -- (Optional) A linear combination of the input
       variables that separates the critical point solutions
@@ -1302,23 +1291,22 @@ def CriticalPoints(G, H, variables, r=None, linear_form=None, m2=None, whitney_s
         sage: pts = CriticalPoints(
         ....:     1,
         ....:     (1-(2*x+y)/3)*(1-(3*x+y)/4),
-        ....:     ([x, y], lambda_, u_)
+        ....:     [x, y],
         ....: )
         sage: sorted(pts)
         [[2/3, 2], [3/4, 3/2], [1, 1]]
 
     """
-    vs, _, _ = variables
     (
         expanded_R,
         vs,
         (lambda_, u_),
         r,
         r_variable_values,
-    ) = _prepare_expanded_polynomial_ring(vs, direction=r, include_t=False)
+    ) = _prepare_expanded_polynomial_ring(variables, direction=r, include_t=False)
     H = expanded_R(H)
 
-    vsT = vs + list(r_variable_values.keys())+ [lambda_]
+    vsT = vs + list(r_variable_values.keys()) + [lambda_]
 
     # Compute the critical point system for each stratum
     pure_H = PolynomialRing(QQ, vs)
@@ -1411,7 +1399,7 @@ def _prepare_expanded_polynomial_ring(variables, direction=None, include_t=True)
     # create the expanded polynomial ring
     expanded_ring = PolynomialRing(
         QQ,
-        variables + list(direction_variable_values) + auxiliary_variables
+        list(variables) + list(direction_variable_values) + auxiliary_variables
     )
     variables = [expanded_ring(v) for v in variables]
     auxiliary_variables = [

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+from sage.rings.qqbar import QQbar, AlgebraicNumber
+
 from sage.all import AA, QQ, SR, Ideal, Polyhedron, ceil, gcd, matrix, randint, vector, kronecker_delta
 
+
+def collapse_zero_part(algebraic_number: AlgebraicNumber) -> AlgebraicNumber:
+    if algebraic_number.real().is_zero():
+        algebraic_number = QQbar(algebraic_number.imag()) * QQbar(-1).sqrt()
+    if algebraic_number.imag().is_zero():
+        algebraic_number = QQbar(algebraic_number.real())
+    return algebraic_number
 
 def RationalFunctionReduce(G, H):
     r"""Reduction of G and H by dividing out their GCD.

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -54,7 +54,7 @@ class ACSVSettings:
     Output = OutputFormat
     _default_output_format = DEFAULT_OUTPUT_FORMAT
 
-    MAX_MIN_CRIT_RETRIES = 3  # Maximum number of retries for critical point detection
+    MAX_MIN_CRIT_RETRIES = 5  # Maximum number of retries for critical point detection
 
     @classmethod
     def set_default_output_format(cls, output_format: OutputFormat | str | None = None) -> None:


### PR DESCRIPTION
This PR...

- renames `diagonal_asy_smooth -> _diagonal_asy_smooth`, marking the function as "private"
- moves the examples from `diagonal_asy_smooth` to `diagonal_asy`
- factors out an epsilon of common code (there is potential to pull out way more still)
- adds a mechanism (`helpers.collapse_zero_part`) that eliminates the weird looking `0.?e-53 + ...` parts from algebraic numbers that actually have a 0 real/imaginary part