### PR TITLE
Refactor and fix `get_coefficients` -> `get_expansion_terms`

### DIFF
--- a/sage_acsv/__init__.py
+++ b/sage_acsv/__init__.py
@@ -8,7 +8,7 @@ The public interface of our toolbox is provided by the following
 functions and classes:
 
 - :func:`.diagonal_asy` -- the central function of the package,
-- :func:`.get_coefficients` --
+- :func:`.get_expansion_terms` --
 - :func:`.ContributingCombinatorial` --
 - :func:`.MinimalCriticalCombinatorial` --
 - :func:`.CriticalPoints` -- 
@@ -18,7 +18,7 @@ The following exmples illustrate some typical use cases. We
 first import relevant functions and define the required
 symbolic variables::
 
-    sage: from sage_acsv import diagonal_asy, get_coefficients
+    sage: from sage_acsv import diagonal_asy, get_expansion_terms
     sage: var('w x y z')
     (w, x, y, z)
 
@@ -58,9 +58,9 @@ irrationality of `\zeta(3)`::
 While the representation might suggest otherwise, the numerical
 constants in the expansion are not approximations, but in fact
 explicitly known algebraic numbers. We can use the
-:func:`.get_coefficients` function to inspect them closer::
+:func:`.get_expansion_terms` function to inspect them closer::
 
-    sage: coefs = get_coefficients(apery_expansion); coefs
+    sage: coefs = get_expansion_terms(apery_expansion); coefs
     [Term(coefficient=1.225275868941647?, pi_factor=pi^(-3/2), base=33.97056274847714?, power=-3/2),
      Term(coefficient=-0.5128314911970734?, pi_factor=pi^(-3/2), base=33.97056274847714?, power=-5/2)]
     sage: coefs[0].coefficient.radical_expression()
@@ -115,5 +115,5 @@ very close moduli::
 
 from sage_acsv.asymptotics import *
 from sage_acsv.kronecker import *
-from sage_acsv.helpers import get_coefficients
+from sage_acsv.helpers import get_expansion_terms
 from sage_acsv.settings import ACSVSettings

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -386,7 +386,7 @@ def IsContributing(vs, pt, r, factors, c):
         )
     return True
 
-def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansion) -> list[Term]:
+def get_expansion_terms(expr: tuple | list[tuple] | Expression | AsymptoticExpansion) -> list[Term]:
     r"""Determines coefficients for each n^k that appears in the asymptotic expression.
     
     INPUT:
@@ -400,25 +400,25 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
 
     EXAMPLES::
 
-        sage: from sage_acsv import diagonal_asy, get_coefficients
+        sage: from sage_acsv import diagonal_asy, get_expansion_terms
         sage: var('x y z')
         (x, y, z)
         sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2)
-        sage: coefs = sorted(get_coefficients(res), reverse=True)
+        sage: coefs = sorted(get_expansion_terms(res), reverse=True)
         sage: coefs
         [Term(coefficient=1, pi_factor=1/sqrt(pi), base=4, power=-1/2),
          Term(coefficient=-1/8, pi_factor=1/sqrt(pi), base=4, power=-3/2)]
         sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="tuple")
-        sage: sorted(get_coefficients(res)) == sorted(coefs)
+        sage: sorted(get_expansion_terms(res)) == sorted(coefs)
         True
         sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="symbolic")
-        sage: sorted(get_coefficients(res)) == sorted(coefs)
+        sage: sorted(get_expansion_terms(res)) == sorted(coefs)
         True
 
     ::
 
         sage: res = diagonal_asy(1/(1 - x^7))
-        sage: get_coefficients(res)
+        sage: get_expansion_terms(res)
         [Term(coefficient=1/7, pi_factor=1, base=e^(I*pi - I*arctan(4.381286267534823?)), power=0),
          Term(coefficient=1/7, pi_factor=1, base=e^(I*pi - I*arctan(0.4815746188075287?)), power=0),
          Term(coefficient=1/7, pi_factor=1, base=e^(-I*pi + I*arctan(4.381286267534823?)), power=0),
@@ -430,7 +430,7 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
     ::
 
         sage: res = diagonal_asy(1/(1 - x - y^2))
-        sage: coefs = get_coefficients(res); coefs
+        sage: coefs = get_expansion_terms(res); coefs
         [Term(coefficient=0.6123724356957945?, pi_factor=1/sqrt(pi), base=-2.598076211353316?, power=-1/2),
          Term(coefficient=0.6123724356957945?, pi_factor=1/sqrt(pi), base=2.598076211353316?, power=-1/2)]
         sage: coefs[0].coefficient.parent()
@@ -442,7 +442,7 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
 
         sage: F2 = (1+x)*(1+y)/(1-z*x*y*(x+y+1/x+1/y))
         sage: res = diagonal_asy(F2, expansion_precision=3)
-        sage: coefs = get_coefficients(res); coefs
+        sage: coefs = get_expansion_terms(res); coefs
         [Term(coefficient=4, pi_factor=1/pi, base=4, power=-1),
          Term(coefficient=1, pi_factor=1/pi, base=-4, power=-3),
          Term(coefficient=-6, pi_factor=1/pi, base=4, power=-2),
@@ -451,13 +451,13 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
     ::
 
         sage: res = diagonal_asy(3/(1 - x))
-        sage: get_coefficients(res)
+        sage: get_expansion_terms(res)
         [Term(coefficient=3, pi_factor=1, base=1, power=0)]
 
     ::
 
         sage: res = diagonal_asy((x - y)/(1 - x - y))
-        sage: get_coefficients(res)
+        sage: get_expansion_terms(res)
         []
 
     """

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -424,12 +424,12 @@ def get_expansion_terms(expr: tuple | list[tuple] | Expression | AsymptoticExpan
         sage: res = diagonal_asy(1/(1 - x^7))
         sage: get_expansion_terms(res)
         [Term(coefficient=1/7, pi_factor=1, base=0.6234898018587335? + 0.7818314824680299?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=0.6234898018587335? - 0.7818314824680299?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=-0.2225209339563144? + 0.9749279121818236?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=-0.2225209339563144? - 0.9749279121818236?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=-0.9009688679024191? + 0.4338837391175582?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=-0.9009688679024191? - 0.4338837391175582?*I, power=0),
-     Term(coefficient=1/7, pi_factor=1, base=1, power=0)]
+         Term(coefficient=1/7, pi_factor=1, base=0.6234898018587335? - 0.7818314824680299?*I, power=0),
+         Term(coefficient=1/7, pi_factor=1, base=-0.2225209339563144? + 0.9749279121818236?*I, power=0),
+         Term(coefficient=1/7, pi_factor=1, base=-0.2225209339563144? - 0.9749279121818236?*I, power=0),
+         Term(coefficient=1/7, pi_factor=1, base=-0.9009688679024191? + 0.4338837391175582?*I, power=0),
+         Term(coefficient=1/7, pi_factor=1, base=-0.9009688679024191? - 0.4338837391175582?*I, power=0),
+         Term(coefficient=1/7, pi_factor=1, base=1, power=0)]
 
     ::
 

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -46,6 +46,7 @@ def collapse_zero_part(algebraic_number: AlgebraicNumber) -> AlgebraicNumber:
         algebraic_number = QQbar(algebraic_number.imag()) * QQbar(-1).sqrt()
     if algebraic_number.imag().is_zero():
         algebraic_number = QQbar(algebraic_number.real())
+    algebraic_number.simplify()
     return algebraic_number
 
 def RationalFunctionReduce(G, H):
@@ -446,6 +447,19 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
          Term(coefficient=1, pi_factor=1/pi, base=-4, power=-3),
          Term(coefficient=-6, pi_factor=1/pi, base=4, power=-2),
          Term(coefficient=19/2, pi_factor=1/pi, base=4, power=-3)]
+
+    ::
+
+        sage: res = diagonal_asy(3/(1 - x))
+        sage: get_coefficients(res)
+        [Term(coefficient=3, pi_factor=1, base=1, power=0)]
+
+    ::
+
+        sage: res = diagonal_asy((x - y)/(1 - x - y))
+        sage: get_coefficients(res)
+        []
+
     """
     n = SR.var('n')
     if isinstance(expr, tuple):
@@ -460,10 +474,12 @@ def get_coefficients(expr: tuple | list[tuple] | Expression | AsymptoticExpansio
     
     if len(expr.args()) > 1:
         raise ACSVException("Cannot process multivariate symbolic expression.")
-    n = expr.args()[0]
 
     # If expression is the sum of a bunch of terms, handle each one separately
     expr = expr.expand()
+    if expr.is_zero():
+        return []
+
     terms = [expr]
     if expr.operator() == add_vararg:
         terms = expr.operands()


### PR DESCRIPTION
This fixes two errors with `get_coefficients` concerning processing symbolic output only consisting of `O( ... )`, or with just a constant main term.

Still to do:

- [x] Rename (to, e.g., `get_expansion_terms`)
- [x] Investigate why the extraction fails in the case where
  ```
  F = (1 + x)*(2*z*x^2*y^2 + 2*z*y^2 - 1)/((-1 + y)*(z*x^2*y^2 + z*y^2 + z*x - 1)*(z*x^2*y^2 + z*y^2 - 1))
  asm = diagonal_asy(F, expansion_precision=3)
  ```