### PR TITLE
Introduce consistent naming scheme across module

### DIFF
--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -265,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import ACSVSettings as AS, CriticalPoints\n",
+    "from sage_acsv import ACSVSettings as AS, critical_points\n",
     "var('w x y z')"
    ]
   },
@@ -287,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CriticalPoints(1/(1 - (w + x + y + z) + 27*w*x*y*z))"
+    "critical_points(1/(1 - (w + x + y + z) + 27*w*x*y*z))"
    ]
   },
   {
@@ -316,7 +316,7 @@
    "outputs": [],
    "source": [
     "F = 1/(1 - (w + x + y + z) + 24*w*x*y*z)\n",
-    "CriticalPoints(F)"
+    "critical_points(F)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asymptotics_combinatorial, get_expansion_terms, ACSVSettings"
+    "from sage_acsv import diagonal_asymptotics_combinatorial as diagonal, get_expansion_terms, ACSVSettings"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(1/(1 - x - y))"
+    "diagonal(1/(1 - x - y))"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[2, 1])"
+    "diagonal(1/(1 - x - y), r=[2, 1])"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ex = diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[2, 1], expansion_precision=2); ex"
+    "ex = diagonal(1/(1 - x - y), r=[2, 1], expansion_precision=2); ex"
    ]
   },
   {
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(F, r=[1, 3])"
+    "diagonal(F, r=[1, 3])"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(F, r=[4, 1])"
+    "diagonal(F, r=[4, 1])"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(F, r=[1, 1])"
+    "diagonal(F, r=[1, 1])"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    diagonal_asymptotics_combinatorial(F, r=[2, 1])\n",
+    "    diagonal(F, r=[2, 1])\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asymptotics_combinatorial(F)"
+    "diagonal(F)"
    ]
   },
   {
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expansion = diagonal_asymptotics_combinatorial(F, expansion_precision=2)\n",
+    "expansion = diagonal(F, expansion_precision=2)\n",
     "expansion"
    ]
   },

--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -235,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import WhitneyStrat\n",
+    "from sage_acsv import whitney_stratification\n",
     "R.<x, y, z> = PolynomialRing(QQ, 3)\n",
     "IX = Ideal(y^2 + z^3 - x^2*z^2); IX"
    ]
@@ -247,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "WhitneyStrat(IX, R)"
+    "whitney_stratification(IX, R)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -305,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import MinimalCriticalCombinatorial"
+    "from sage_acsv import minimal_critical_points_combinatorial"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MinimalCriticalCombinatorial(F)"
+    "minimal_critical_points_combinatorial(F)"
    ]
   },
   {
@@ -344,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import MinimalCriticalCombinatorial, ContributingCombinatorial"
+    "from sage_acsv import minimal_critical_points_combinatorial, ContributingCombinatorial"
    ]
   },
   {
@@ -364,7 +364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MinimalCriticalCombinatorial(F)"
+    "minimal_critical_points_combinatorial(F)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -344,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import minimal_critical_points_combinatorial, ContributingCombinatorial"
+    "from sage_acsv import minimal_critical_points_combinatorial, contributing_points_combinatorial"
    ]
   },
   {
@@ -374,7 +374,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ContributingCombinatorial(F)"
+    "contributing_points_combinatorial(F)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Beyond-Smooth-Examples.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asy, get_expansion_terms, ACSVSettings"
+    "from sage_acsv import diagonal_asymptotics_combinatorial, get_expansion_terms, ACSVSettings"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(1/(1 - x - y))"
+    "diagonal_asymptotics_combinatorial(1/(1 - x - y))"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(1/(1 - x - y), r=[2, 1])"
+    "diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[2, 1])"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ex = diagonal_asy(1/(1 - x - y), r=[2, 1], expansion_precision=2); ex"
+    "ex = diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[2, 1], expansion_precision=2); ex"
    ]
   },
   {
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(F, r=[1, 3])"
+    "diagonal_asymptotics_combinatorial(F, r=[1, 3])"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(F, r=[4, 1])"
+    "diagonal_asymptotics_combinatorial(F, r=[4, 1])"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(F, r=[1, 1])"
+    "diagonal_asymptotics_combinatorial(F, r=[1, 1])"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    diagonal_asy(F, r=[2, 1])\n",
+    "    diagonal_asymptotics_combinatorial(F, r=[2, 1])\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diagonal_asy(F)"
+    "diagonal_asymptotics_combinatorial(F)"
    ]
   },
   {
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expansion = diagonal_asy(F, expansion_precision=2)\n",
+    "expansion = diagonal_asymptotics_combinatorial(F, expansion_precision=2)\n",
     "expansion"
    ]
   },

--- a/examples/Sage-ACSV-Paper-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Examples.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,22 +20,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(x, y, w, z, n, t, lambda_)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make variables to be used later\n",
     "var('x,y,w,z,n,t,lambda_')"
@@ -43,20 +32,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4^n/(sqrt(pi)*sqrt(n))"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 2: Binomial coefficients\n",
     "F = 1/(1-x-y)\n",
@@ -65,20 +43,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.225275868941647?*33.97056274847714?^n/(pi^1.5*n^1.5)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3: Apéry sequence (on main diagonal)\n",
     "F = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))\n",
@@ -87,25 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<html><script type=\"math/tex; mode=display\">\\newcommand{\\Bold}[1]{\\mathbf{#1}}\\frac{{\\left(12 \\, \\sqrt{2} + 17\\right)}^{n} \\sqrt{\\frac{17}{2} \\, \\sqrt{2} + 12}}{4 \\, \\pi^{1.5} n^{1.5}}</script></html>"
-      ],
-      "text/latex": [
-       "$$\\newcommand{\\Bold}[1]{\\mathbf{#1}}\\frac{{\\left(12 \\, \\sqrt{2} + 17\\right)}^{n} \\sqrt{\\frac{17}{2} \\, \\sqrt{2} + 12}}{4 \\, \\pi^{1.5} n^{1.5}}$$"
-      ],
-      "text/plain": [
-       "1/4*(12*sqrt(2) + 17)^n*sqrt(17/2*sqrt(2) + 12)/(pi^1.5*n^1.5)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 3 continued: The quantities here are algebraic of degree two,\n",
     "# so we can represent them in terms of radicals\n",
@@ -115,20 +66,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.9430514023983397?*4.518911369262258?^n/(sqrt(pi)*sqrt(n))"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 7: Pemantle and Wilson Sequence Alignment\n",
     "F = (x^2*y^2-x*y+1)/(1-(x+y+x*y-x*y^2-x^2*y+x^2*y^3+x^3*y^2))\n",
@@ -137,43 +77,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "u_^8 - 18*u_^7 + 146*u_^6 - 692*u_^5 + 2067*u_^4 - 3922*u_^3 + 4553*u_^2 - 2925*u_ + 790\n",
-      "[10*u_^7 - 153*u_^6 + 1046*u_^5 - 4081*u_^4 + 9589*u_^3 - 13270*u_^2 + 9844*u_ - 2985, 10*u_^7 - 154*u_^6 + 1061*u_^5 - 4180*u_^4 + 9954*u_^3 - 14044*u_^2 + 10714*u_ - 3380, -u_^7 + 11*u_^6 - 56*u_^5 + 157*u_^4 - 182*u_^3 - 140*u_^2 + 527*u_ - 335, 8*u_^7 - 139*u_^6 + 1030*u_^5 - 4187*u_^4 + 10021*u_^3 - 14048*u_^2 + 10631*u_ - 3335, -12*u_^7 + 181*u_^6 - 1231*u_^5 + 4801*u_^4 - 11275*u_^3 + 15548*u_^2 - 11452*u_ + 3440]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 12: Kronecker Representation\n",
-    "from sage_acsv import kronecker\n",
+    "from sage_acsv import kronecker_representation\n",
     "# Extended Critical Point System\n",
     "ECPS = [x*y*z - x*z + x - lambda_, x*y*z - y*z + y - lambda_, x*y*z - x*z - y*z + z - lambda_,\n",
     "x*y*z - x*z - y*z + x + y + z - 1,x*y*z*t^3 - x*z*t^2 - y*z*t^2 + x*t + y*t + z*t -1]\n",
     "# Choose u = x + t as the linear form\n",
-    "P, Qs = kronecker(ECPS, [x, y, z, t, lambda_], x + t)\n",
+    "P, Qs = kronecker_representation(ECPS, [x, y, z, t, lambda_], x + t)\n",
     "print(P)\n",
     "print(Qs)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[0.3819660112501051?, 0.3819660112501051?, 0.618033988749895?]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Example 12: Identifying minimal critical points from the Kronecker Representation\n",
     "#\n",
@@ -215,17 +138,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[0.3819660112501051?, 0.3819660112501051?, 0.618033988749895?]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Actual output from MinimialCriticalCombinatorial for the previous example\n",
     "R.<x, y, z, lambda_, t, u_> = QQ[]\n",
@@ -235,20 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.113516364411607?*11.09016994374948?^n/(pi^1.0*n^1.0)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Actual asympototics for the previous example\n",
     "F = 1/(1-x-y-z*(1-x)*(1-y))\n",

--- a/examples/Sage-ACSV-Paper-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Examples.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asymptotics_combinatorial"
+    "from sage_acsv import diagonal_asymptotics_combinatorial as diagonal"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "source": [
     "# Example 2: Binomial coefficients\n",
     "F = 1/(1-x-y)\n",
-    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
+    "diagonal(F, as_symbolic=True)"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "# Example 3: Apéry sequence (on main diagonal)\n",
     "F = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))\n",
-    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
+    "diagonal(F, as_symbolic=True)"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "source": [
     "# Example 3 continued: The quantities here are algebraic of degree two,\n",
     "# so we can represent them in terms of radicals\n",
-    "asm_vals = diagonal_asymptotics_combinatorial(F)\n",
+    "asm_vals = diagonal(F)\n",
     "show(add([a.radical_expression()^n*b*c*d.radical_expression() for (a,b,c,d) in asm_vals]))"
    ]
   },
@@ -72,7 +72,7 @@
    "source": [
     "# Example 7: Pemantle and Wilson Sequence Alignment\n",
     "F = (x^2*y^2-x*y+1)/(1-(x+y+x*y-x*y^2-x^2*y+x^2*y^3+x^3*y^2))\n",
-    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
+    "diagonal(F, as_symbolic=True)"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "source": [
     "# Actual asympototics for the previous example\n",
     "F = 1/(1-x-y-z*(1-x)*(1-y))\n",
-    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
+    "diagonal(F, as_symbolic=True)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Examples.ipynb
@@ -105,7 +105,7 @@
     "# those that are not minimal by examining solutions with t coordinate in (0, 1), and \n",
     "# identify which critical points have the same coordinate-wise modulus.\n",
     "#\n",
-    "# All of these computations have been implemented in the function MinimalCriticalCombinatorial.\n",
+    "# All of these computations have been implemented in the function minimal_critical_points_combinatorial.\n",
     "\n",
     "# Here, we use the P and Qs computed above\n",
     "Qt = Qs[-2]  # Qs ordering is H.variables() + [t, lambda_]\n",
@@ -144,8 +144,8 @@
    "source": [
     "# Actual output from MinimialCriticalCombinatorial for the previous example\n",
     "R.<x, y, z, lambda_, t, u_> = QQ[]\n",
-    "from sage_acsv import MinimalCriticalCombinatorial\n",
-    "print(MinimalCriticalCombinatorial(1,1-x-y-z*(1-x)*(1-y),([x, y, z], lambda_, t, u_)))"
+    "from sage_acsv import minimal_critical_points_combinatorial\n",
+    "print(minimal_critical_points_combinatorial(1,1-x-y-z*(1-x)*(1-y),([x, y, z], lambda_, t, u_)))"
    ]
   },
   {

--- a/examples/Sage-ACSV-Paper-Examples.ipynb
+++ b/examples/Sage-ACSV-Paper-Examples.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asy"
+    "from sage_acsv import diagonal_asymptotics_combinatorial"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "source": [
     "# Example 2: Binomial coefficients\n",
     "F = 1/(1-x-y)\n",
-    "diagonal_asy(F, as_symbolic=True)"
+    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "# Example 3: Apéry sequence (on main diagonal)\n",
     "F = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))\n",
-    "diagonal_asy(F, as_symbolic=True)"
+    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "source": [
     "# Example 3 continued: The quantities here are algebraic of degree two,\n",
     "# so we can represent them in terms of radicals\n",
-    "asm_vals = diagonal_asy(F)\n",
+    "asm_vals = diagonal_asymptotics_combinatorial(F)\n",
     "show(add([a.radical_expression()^n*b*c*d.radical_expression() for (a,b,c,d) in asm_vals]))"
    ]
   },
@@ -72,7 +72,7 @@
    "source": [
     "# Example 7: Pemantle and Wilson Sequence Alignment\n",
     "F = (x^2*y^2-x*y+1)/(1-(x+y+x*y-x*y^2-x^2*y+x^2*y^3+x^3*y^2))\n",
-    "diagonal_asy(F, as_symbolic=True)"
+    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "source": [
     "# Actual asympototics for the previous example\n",
     "F = 1/(1-x-y-z*(1-x)*(1-y))\n",
-    "diagonal_asy(F, as_symbolic=True)"
+    "diagonal_asymptotics_combinatorial(F, as_symbolic=True)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Tests.ipynb
+++ b/examples/Sage-ACSV-Tests.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asy"
+    "from sage_acsv import diagonal_asymptotics_combinatorial"
    ]
   },
   {
@@ -27,7 +27,7 @@
    "source": [
     "# Binomial coefficients\n",
     "F1 = 1/(1-x-y)\n",
-    "diagonal_asy(F1)"
+    "diagonal_asymptotics_combinatorial(F1)"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "source": [
     "# Multiple terms in series expansion\n",
     "F1 = (2*y^2-x)/(x+y-1)\n",
-    "diagonal_asy(F1, expansion_precision=3)"
+    "diagonal_asymptotics_combinatorial(F1, expansion_precision=3)"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "# Lattice paths enumeration sequence (on main diagonal)\n",
     "F2 = (1+x)*(1+y)/(1-w*x*y*(x+y+1/x+1/y))\n",
-    "diagonal_asy(F2, expansion_precision=3)"
+    "diagonal_asymptotics_combinatorial(F2, expansion_precision=3)"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "source": [
     "# Apéry sequence (on main diagonal)\n",
     "F3 = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))\n",
-    "diagonal_asy(F3, expansion_precision=2)"
+    "diagonal_asymptotics_combinatorial(F3, expansion_precision=2)"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# The quantities here are algebraic of degree two, so we can represent them in radicals\n",
-    "asm_vals = diagonal_asy(F3, output_format=\"tuple\")\n",
+    "asm_vals = diagonal_asymptotics_combinatorial(F3, output_format=\"tuple\")\n",
     "show(add([a.radical_expression()^n*b*c*QQbar(d).radical_expression() for (a,b,c,d) in asm_vals]))"
    ]
   },
@@ -82,7 +82,7 @@
    "source": [
     "# Example with two critical points with positive coords, neither of which is obviously non-minimal\n",
     "F4 = -1/(1-(1-x-y)*(20-x-40*y))\n",
-    "diagonal_asy(F4)"
+    "diagonal_asymptotics_combinatorial(F4)"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "source": [
     "# Same example, computing an extra term\n",
     "F4 = -1/(1-(1-x-y)*(20-x-40*y))\n",
-    "diagonal_asy(F4, expansion_precision=2)"
+    "diagonal_asymptotics_combinatorial(F4, expansion_precision=2)"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "# Example with no critical points in (1,1)-direction\n",
     "F5 = 1/(x^4*y + x^3*y + x^2*y + x*y - 1)\n",
     "try:\n",
-    "    diagonal_asy(F5)\n",
+    "    diagonal_asymptotics_combinatorial(F5)\n",
     "except Exception as e:\n",
     "    print(f\"No result was computed: {e}\")"
    ]
@@ -119,7 +119,7 @@
     "# Another example with no critical points \n",
     "F6 = 1/((-x + 1)^4 - x*y*(x^3 + x^2*y - x^2 - x + 1))\n",
     "try:\n",
-    "    diagonal_asy(F6)\n",
+    "    diagonal_asymptotics_combinatorial(F6)\n",
     "except Exception as e:\n",
     "    print(f\"No result was computed: {e}\")"
    ]
@@ -132,7 +132,7 @@
    "source": [
     "# Delannoy generating function\n",
     "F7 = 1/(1 - x - y - x*y)\n",
-    "diagonal_asy(F7)"
+    "diagonal_asymptotics_combinatorial(F7)"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "source": [
     "# One variable example with many minimal critical points on same torus\n",
     "F8 = 1/(1 - x^7)\n",
-    "diagonal_asy(F8)"
+    "diagonal_asymptotics_combinatorial(F8)"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "source": [
     "# One variable example having singularities with close moduli\n",
     "F9 = 1/(8 - 17*x^3 - 9*x^2 + 7*x)\n",
-    "diagonal_asy(F9, return_points=True)"
+    "diagonal_asymptotics_combinatorial(F9, return_points=True)"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "F10 = (x^2*y^2 - x*y + 1)/(1-x-y-x*y+x*y^2+x^2*y-x^2*y^3-x^3*y^2)\n",
-    "diagonal_asy(F10)"
+    "diagonal_asymptotics_combinatorial(F10)"
    ]
   },
   {

--- a/examples/Sage-ACSV-Tests.ipynb
+++ b/examples/Sage-ACSV-Tests.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sage_acsv import diagonal_asymptotics_combinatorial"
+    "from sage_acsv import diagonal_asymptotics_combinatorial as diagonal"
    ]
   },
   {
@@ -27,7 +27,7 @@
    "source": [
     "# Binomial coefficients\n",
     "F1 = 1/(1-x-y)\n",
-    "diagonal_asymptotics_combinatorial(F1)"
+    "diagonal(F1)"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "source": [
     "# Multiple terms in series expansion\n",
     "F1 = (2*y^2-x)/(x+y-1)\n",
-    "diagonal_asymptotics_combinatorial(F1, expansion_precision=3)"
+    "diagonal(F1, expansion_precision=3)"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "# Lattice paths enumeration sequence (on main diagonal)\n",
     "F2 = (1+x)*(1+y)/(1-w*x*y*(x+y+1/x+1/y))\n",
-    "diagonal_asymptotics_combinatorial(F2, expansion_precision=3)"
+    "diagonal(F2, expansion_precision=3)"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "source": [
     "# Apéry sequence (on main diagonal)\n",
     "F3 = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))\n",
-    "diagonal_asymptotics_combinatorial(F3, expansion_precision=2)"
+    "diagonal(F3, expansion_precision=2)"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# The quantities here are algebraic of degree two, so we can represent them in radicals\n",
-    "asm_vals = diagonal_asymptotics_combinatorial(F3, output_format=\"tuple\")\n",
+    "asm_vals = diagonal(F3, output_format=\"tuple\")\n",
     "show(add([a.radical_expression()^n*b*c*QQbar(d).radical_expression() for (a,b,c,d) in asm_vals]))"
    ]
   },
@@ -82,7 +82,7 @@
    "source": [
     "# Example with two critical points with positive coords, neither of which is obviously non-minimal\n",
     "F4 = -1/(1-(1-x-y)*(20-x-40*y))\n",
-    "diagonal_asymptotics_combinatorial(F4)"
+    "diagonal(F4)"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "source": [
     "# Same example, computing an extra term\n",
     "F4 = -1/(1-(1-x-y)*(20-x-40*y))\n",
-    "diagonal_asymptotics_combinatorial(F4, expansion_precision=2)"
+    "diagonal(F4, expansion_precision=2)"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "# Example with no critical points in (1,1)-direction\n",
     "F5 = 1/(x^4*y + x^3*y + x^2*y + x*y - 1)\n",
     "try:\n",
-    "    diagonal_asymptotics_combinatorial(F5)\n",
+    "    diagonal(F5)\n",
     "except Exception as e:\n",
     "    print(f\"No result was computed: {e}\")"
    ]
@@ -119,7 +119,7 @@
     "# Another example with no critical points \n",
     "F6 = 1/((-x + 1)^4 - x*y*(x^3 + x^2*y - x^2 - x + 1))\n",
     "try:\n",
-    "    diagonal_asymptotics_combinatorial(F6)\n",
+    "    diagonal(F6)\n",
     "except Exception as e:\n",
     "    print(f\"No result was computed: {e}\")"
    ]
@@ -132,7 +132,7 @@
    "source": [
     "# Delannoy generating function\n",
     "F7 = 1/(1 - x - y - x*y)\n",
-    "diagonal_asymptotics_combinatorial(F7)"
+    "diagonal(F7)"
    ]
   },
   {
@@ -143,7 +143,7 @@
    "source": [
     "# One variable example with many minimal critical points on same torus\n",
     "F8 = 1/(1 - x^7)\n",
-    "diagonal_asymptotics_combinatorial(F8)"
+    "diagonal(F8)"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "source": [
     "# One variable example having singularities with close moduli\n",
     "F9 = 1/(8 - 17*x^3 - 9*x^2 + 7*x)\n",
-    "diagonal_asymptotics_combinatorial(F9, return_points=True)"
+    "diagonal(F9, return_points=True)"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "F10 = (x^2*y^2 - x*y + 1)/(1-x-y-x*y+x*y^2+x^2*y-x^2*y^3-x^3*y^2)\n",
-    "diagonal_asymptotics_combinatorial(F10)"
+    "diagonal(F10)"
    ]
   },
   {

--- a/sage_acsv/__init__.py
+++ b/sage_acsv/__init__.py
@@ -7,7 +7,7 @@ several variables along a given direction.
 The public interface of our toolbox is provided by the following
 functions and classes:
 
-- :func:`.diagonal_asy` -- the central function of the package,
+- :func:`.diagonal_asymptotics_combinatorial` -- the central function of the package,
 - :func:`.get_expansion_terms` -- helper function for extracting
   the terms in the output expansion with more structure,
 - :func:`.ContributingCombinatorial` -- computes all contributing
@@ -17,14 +17,14 @@ functions and classes:
 - :func:`.CriticalPoints` -- compute all critical points of a combinatorial
   multivariate rational function,
 - :class:`.ACSVSettings` -- a class for managing several package-global
-  settings (like the default output format for :func:`.diagonal_asy`,
+  settings (like the default output format for :func:`.diagonal_asymptotics_combinatorial`,
   or the backend used for Gröbner basis computations).
 
 The following exmples illustrate some typical use cases. We
 first import relevant functions and define the required
 symbolic variables::
 
-    sage: from sage_acsv import diagonal_asy, get_expansion_terms
+    sage: from sage_acsv import diagonal_asymptotics_combinatorial, get_expansion_terms
     sage: var('w x y z')
     (w, x, y, z)
 
@@ -33,32 +33,32 @@ coefficients, `\binom{2n}{n}`, generated along the `(1, 1)`-diagonal
 of `F(x, y) = \frac{1}{1 - x - y}` is simply computed as
 ::
 
-    sage: diagonal_asy(1 / (1 - x - y))
+    sage: diagonal_asymptotics_combinatorial(1 / (1 - x - y))
     1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
 
 The precision of the expansion can be controlled by the
 ``expansion_precision`` keyword argument::
 
-    sage: diagonal_asy(1 / (1 - x - y), expansion_precision=4)
+    sage: diagonal_asymptotics_combinatorial(1 / (1 - x - y), expansion_precision=4)
     1/sqrt(pi)*4^n*n^(-1/2) - 1/8/sqrt(pi)*4^n*n^(-3/2) + 1/128/sqrt(pi)*4^n*n^(-5/2) + 5/1024/sqrt(pi)*4^n*n^(-7/2) + O(4^n*n^(-9/2))
 
 ::
 
     sage: F1 = (2*y^2 - x)/(x + y - 1)
-    sage: diagonal_asy(F1, expansion_precision=3)
+    sage: diagonal_asymptotics_combinatorial(F1, expansion_precision=3)
     1/4/sqrt(pi)*4^n*n^(-3/2) + 3/32/sqrt(pi)*4^n*n^(-5/2) + O(4^n*n^(-7/2))
 
 ::
 
     sage: F2 = (1+x)*(1+y)/(1-w*x*y*(x+y+1/x+1/y))
-    sage: diagonal_asy(F2, expansion_precision=3)
+    sage: diagonal_asymptotics_combinatorial(F2, expansion_precision=3)
     4/pi*4^n*n^(-1) - 6/pi*4^n*n^(-2) + 1/pi*4^n*n^(-3)*(e^(I*arg(-1)))^n + 19/2/pi*4^n*n^(-3) + O(4^n*n^(-4))
 
 The following example is from Apéry's proof concerning the
 irrationality of `\zeta(3)`::
 
     sage: F3 = 1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1))
-    sage: apery_expansion = diagonal_asy(F3, expansion_precision=2); apery_expansion
+    sage: apery_expansion = diagonal_asymptotics_combinatorial(F3, expansion_precision=2); apery_expansion
     1.225275868941647?/pi^(3/2)*33.97056274847714?^n*n^(-3/2) - 0.5128314911970734?/pi^(3/2)*33.97056274847714?^n*n^(-5/2) + O(33.97056274847714?^n*n^(-7/2))
 
 While the representation might suggest otherwise, the numerical
@@ -77,14 +77,14 @@ explicitly known algebraic numbers. We can use the
 ::
 
     sage: F4 = -1/(1 - (1 - x - y)*(20 - x - 40*y))
-    sage: diagonal_asy(F4, expansion_precision=2)
+    sage: diagonal_asymptotics_combinatorial(F4, expansion_precision=2)
     0.09677555757474702?/sqrt(pi)*5.884442204019508?^n*n^(-1/2) + 0.002581950724843528?/sqrt(pi)*5.884442204019508?^n*n^(-3/2) + O(5.884442204019508?^n*n^(-5/2))
 
 The package raises an exception if it detects that some of the
 requirements are not met::
 
     sage: F5 = 1/(x^4*y + x^3*y + x^2*y + x*y - 1)
-    sage: diagonal_asy(F5)
+    sage: diagonal_asymptotics_combinatorial(F5)
     Traceback (most recent call last):
     ...
     ACSVException: No smooth minimal critical points found.
@@ -92,7 +92,7 @@ requirements are not met::
 ::
 
     sage: F6 = 1/((-x + 1)^4 - x*y*(x^3 + x^2*y - x^2 - x + 1))
-    sage: diagonal_asy(F6)  # long time
+    sage: diagonal_asymptotics_combinatorial(F6)  # long time
     Traceback (most recent call last):
     ...
     ACSVException: No contributing points found.
@@ -100,20 +100,20 @@ requirements are not met::
 Here is the asymptotic growth of the Delannoy numbers::
 
     sage: F7 = 1/(1 - x - y - x*y)
-    sage: diagonal_asy(F7)
+    sage: diagonal_asymptotics_combinatorial(F7)
     1.015051765128218?/sqrt(pi)*5.828427124746190?^n*n^(-1/2) + O(5.828427124746190?^n*n^(-3/2))
 
 ::
 
     sage: F8 = 1/(1 - x^7)
-    sage: diagonal_asy(F8)
+    sage: diagonal_asymptotics_combinatorial(F8)
     1/7 + 1/7*(e^(I*arg(-0.2225209339563144? + 0.9749279121818236?*I)))^n + 1/7*(e^(I*arg(-0.2225209339563144? - 0.9749279121818236?*I)))^n + 1/7*(e^(I*arg(-0.9009688679024191? + 0.4338837391175581?*I)))^n + 1/7*(e^(I*arg(-0.9009688679024191? - 0.4338837391175581?*I)))^n + 1/7*(e^(I*arg(0.6234898018587335? + 0.7818314824680299?*I)))^n + 1/7*(e^(I*arg(0.6234898018587335? - 0.7818314824680299?*I)))^n + O(n^(-1))
 
 This example is for a generating function whose singularities have
 very close moduli::
 
     sage: F9 = 1/(8 - 17*x^3 - 9*x^2 + 7*x)
-    sage: diagonal_asy(F9, return_points=True)
+    sage: diagonal_asymptotics_combinatorial(F9, return_points=True)
     (0.03396226416457560?*1.285654384750451?^n + O(1.285654384750451?^n*n^(-1)),
      [[0.7778140158516262?]])
 

--- a/sage_acsv/__init__.py
+++ b/sage_acsv/__init__.py
@@ -14,7 +14,7 @@ functions and classes:
   points of a combinatorial multivariate rational function,
 - :func:`.MinimalCriticalCombinatorial` -- computes all non-zero minimal
   critical points of a combinatorial multivariate rational function,
-- :func:`.CriticalPoints` -- compute all critical points of a combinatorial
+- :func:`.critical_points` -- compute all critical points of a combinatorial
   multivariate rational function,
 - :class:`.ACSVSettings` -- a class for managing several package-global
   settings (like the default output format for :func:`.diagonal_asymptotics_combinatorial`,

--- a/sage_acsv/__init__.py
+++ b/sage_acsv/__init__.py
@@ -10,7 +10,7 @@ functions and classes:
 - :func:`.diagonal_asymptotics_combinatorial` -- the central function of the package,
 - :func:`.get_expansion_terms` -- helper function for extracting
   the terms in the output expansion with more structure,
-- :func:`.ContributingCombinatorial` -- computes all contributing
+- :func:`.contributing_points_combinatorial` -- computes all contributing
   points of a combinatorial multivariate rational function,
 - :func:`.minimal_critical_points_combinatorial` -- computes all non-zero minimal
   critical points of a combinatorial multivariate rational function,

--- a/sage_acsv/__init__.py
+++ b/sage_acsv/__init__.py
@@ -12,7 +12,7 @@ functions and classes:
   the terms in the output expansion with more structure,
 - :func:`.ContributingCombinatorial` -- computes all contributing
   points of a combinatorial multivariate rational function,
-- :func:`.MinimalCriticalCombinatorial` -- computes all non-zero minimal
+- :func:`.minimal_critical_points_combinatorial` -- computes all non-zero minimal
   critical points of a combinatorial multivariate rational function,
 - :func:`.critical_points` -- compute all critical points of a combinatorial
   multivariate rational function,

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -56,7 +56,7 @@ def strip_symbolic(expression):
 asy_misc.strip_symbolic = strip_symbolic
 
 
-def _diagonal_asy_smooth(
+def _diagonal_asymptotics_combinatorial_smooth(
     G,
     H,
     r=None,
@@ -109,20 +109,20 @@ def _diagonal_asy_smooth(
 
     See also:
 
-    - :func:`.diagonal_asy`
+    - :func:`.diagonal_asymptotics_combinatorial`
 
     TESTS:
 
     Check that passing a non-supported ``output_format`` errors out::
 
-        sage: from sage_acsv import diagonal_asy
+        sage: from sage_acsv import diagonal_asymptotics_combinatorial
         sage: var('x y')
         (x, y)
-        sage: diagonal_asy(1/(1 - x - y), output_format='hello world')  # indirect doctest
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y), output_format='hello world')  # indirect doctest
         Traceback (most recent call last):
         ...
         ValueError: 'hello world' is not a valid OutputFormat
-        sage: diagonal_asy(1/(1 - x - y), output_format=42)  # indirect doctest
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y), output_format=42)  # indirect doctest
         Traceback (most recent call last):
         ...
         ValueError: 42 is not a valid OutputFormat
@@ -250,8 +250,36 @@ def _diagonal_asy_smooth(
 
     return result
 
-
 def diagonal_asy(
+    F,
+    r=None,
+    linear_form=None,
+    expansion_precision=1,
+    return_points=False,
+    output_format=None,
+    whitney_strat=None,
+    as_symbolic=False,
+):
+    from warnings import warn
+    warn(
+        "diagonal_asy is deprecated and will be removed in a future release. "
+        "Please use diagonal_asymptotics_combinatorial (same signature) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return diagonal_asymptotics_combinatorial(
+        F,
+        r=r,
+        linear_form=linear_form,
+        expansion_precision=expansion_precision,
+        return_points=return_points,
+        output_format=output_format,
+        whitney_strat=whitney_strat,
+        as_symbolic=as_symbolic,
+    )
+
+
+def diagonal_asymptotics_combinatorial(
     F,
     r=None,
     linear_form=None,
@@ -314,20 +342,20 @@ def diagonal_asy(
 
     EXAMPLES:
 
-        sage: from sage_acsv import diagonal_asy
+        sage: from sage_acsv import diagonal_asymptotics_combinatorial
         sage: var('x,y,z,w')
         (x, y, z, w)
-        sage: diagonal_asy(1/(1-x-y))
+        sage: diagonal_asymptotics_combinatorial(1/(1-x-y))
         1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
-        sage: diagonal_asy(1/(1-(1+x)*y), r = [1,2], return_points=True)
+        sage: diagonal_asymptotics_combinatorial(1/(1-(1+x)*y), r = [1,2], return_points=True)
         (1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2)), [[1, 1/2]])
-        sage: diagonal_asy(1/(1-(x+y+z)+(3/4)*x*y*z), output_format="symbolic")
+        sage: diagonal_asymptotics_combinatorial(1/(1-(x+y+z)+(3/4)*x*y*z), output_format="symbolic")
         0.840484893481498?*24.68093482214177?^n/(pi*n)
-        sage: diagonal_asy(1/(1-(x+y+z)+(3/4)*x*y*z))
+        sage: diagonal_asymptotics_combinatorial(1/(1-(x+y+z)+(3/4)*x*y*z))
         0.840484893481498?/pi*24.68093482214177?^n*n^(-1) + O(24.68093482214177?^n*n^(-2))
         sage: var('n')
         n
-        sage: asy = diagonal_asy(
+        sage: asy = diagonal_asymptotics_combinatorial(
         ....:     1/(1 - w*(1 + x)*(1 + y)*(1 + z)*(x*y*z + y*z + y + z + 1)),
         ....:     output_format="tuple",
         ....: )
@@ -340,15 +368,15 @@ def diagonal_asy(
     Not specifying any ``output_format`` falls back to the default asymptotic
     representation::
 
-        sage: diagonal_asy(1/(1 - 2*x))
+        sage: diagonal_asymptotics_combinatorial(1/(1 - 2*x))
         2^n + O(2^n*n^(-1))
-        sage: diagonal_asy(1/(1 - 2*x), output_format="tuple")
+        sage: diagonal_asymptotics_combinatorial(1/(1 - 2*x), output_format="tuple")
         [(2, 1, 1, 1)]
 
     Passing ``"symbolic"`` lets the function return an element of the
     symbolic ring in the variable ``n`` that describes the asymptotic growth::
 
-        sage: growth = diagonal_asy(1/(1 - 2*x), output_format="symbolic"); growth
+        sage: growth = diagonal_asymptotics_combinatorial(1/(1 - 2*x), output_format="symbolic"); growth
         2^n
         sage: growth.parent()
         Symbolic Ring
@@ -358,7 +386,7 @@ def diagonal_asy(
     appropriate error term::
 
         sage: assume(SR.an_element() > 0)  # required to make coercions involving SR work properly
-        sage: growth = diagonal_asy(1/(1 - x - y), output_format="asymptotic"); growth
+        sage: growth = diagonal_asymptotics_combinatorial(1/(1 - x - y), output_format="asymptotic"); growth
         1/sqrt(pi)*4^n*n^(-1/2) + O(4^n*n^(-3/2))
         sage: growth.parent()
         Asymptotic Ring <(Algebraic Real Field)^n * n^QQ * (Arg_(Algebraic Field))^n> over Symbolic Ring
@@ -366,7 +394,7 @@ def diagonal_asy(
     Increasing the precision of the expansion returns an expansion with more terms
     (works for all available output formats)::
 
-        sage: diagonal_asy(1/(1 - x - y), expansion_precision=3, output_format="asymptotic")
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y), expansion_precision=3, output_format="asymptotic")
         1/sqrt(pi)*4^n*n^(-1/2) - 1/8/sqrt(pi)*4^n*n^(-3/2) + 1/128/sqrt(pi)*4^n*n^(-5/2)
         + O(4^n*n^(-7/2))
 
@@ -374,18 +402,18 @@ def diagonal_asy(
     vector of all 1's) if not specified. It also supports passing non-integer values,
     notably rational numbers::
 
-        sage: diagonal_asy(1/(1 - x - y), r=(1, 17/42), output_format="symbolic")
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y), r=(1, 17/42), output_format="symbolic")
         1.317305628032865?*2.324541507270374?^n/(sqrt(pi)*sqrt(n))
 
     and even algebraic numbers (note, however, that the performance for complicated
     algebraic numbers is significantly degraded)::
 
-        sage: diagonal_asy(1/(1 - x - y), r=(sqrt(2), 1))
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y), r=(sqrt(2), 1))
         0.9238795325112868?/sqrt(pi)*(2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-1/2) + O((2.414213562373095?/0.5857864376269049?^1.414213562373095?)^n*n^(-3/2))
 
     ::
 
-        sage: diagonal_asy(1/(1 - x - y*x^2), r=(1, 1/2 - 1/2*sqrt(1/5)), output_format="asymptotic")
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y*x^2), r=(1, 1/2 - 1/2*sqrt(1/5)), output_format="asymptotic")
         1.710862642974252?/sqrt(pi)*1.618033988749895?^n*n^(-1/2)
         + O(1.618033988749895?^n*n^(-3/2))
 
@@ -395,7 +423,7 @@ def diagonal_asy(
         sage: import logging
         sage: from sage_acsv import ACSVSettings
         sage: ACSVSettings.set_logging_level(logging.INFO)
-        sage: diagonal_asy(1/(1 - x - y))
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x - y))
         INFO:sage_acsv:... Executed Kronecker in ... seconds.
         INFO:sage_acsv:... Executed Minimal Points in ... seconds.
         INFO:sage_acsv:... Executed Final Asymptotics in ... seconds.
@@ -405,10 +433,10 @@ def diagonal_asy(
     Extraction of coefficient asymptotics even works in cases where the singular variety of `F`
     is not smooth::
 
-        sage: diagonal_asy(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
+        sage: diagonal_asymptotics_combinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
         12 + O(n^(-1))
 
-        sage: diagonal_asy(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
+        sage: diagonal_asymptotics_combinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)), r = [17/24, 7/24], output_format = 'asymptotic')
         12 + O(n^(-1))
         sage: G = (1+x)*(1-x*y^2+x^2)
         sage: H = (1-z*(1+x^2+x*y^2))*(1-y)*(1+x^2)
@@ -417,7 +445,7 @@ def diagonal_asy(
         ....:     [(1-z*(1+x^2+x*y^2), 1-y),(1-z*(1+x^2+x*y^2), 1+x^2),(1-y,1+x^2)],
         ....:     [(H,)],
         ....: ]
-        sage: diagonal_asy(G/H, r = [1,1,1], output_format = 'asymptotic', whitney_strat = strat)
+        sage: diagonal_asymptotics_combinatorial(G/H, r = [1,1,1], output_format = 'asymptotic', whitney_strat = strat)
         0.866025403784439?/sqrt(pi)*3^n*n^(-1/2) + O(3^n*n^(-3/2))
 
     TESTS:
@@ -425,14 +453,14 @@ def diagonal_asy(
     Check that the workaround for the AsymptoticRing swallowing
     the modulus works as intended::
 
-        sage: diagonal_asy(1/(1 - x^4 - y^4))  # long time
+        sage: diagonal_asymptotics_combinatorial(1/(1 - x^4 - y^4))  # long time
         1/2/sqrt(pi)*1.414213562373095?^n*n^(-1/2) + 1/2/sqrt(pi)*1.414213562373095?^n*n^(-1/2)*(e^(I*arg(-1)))^n + 1/2/sqrt(pi)*1.414213562373095?^n*n^(-1/2)*(e^(I*arg(-I)))^n + 1/2/sqrt(pi)*1.414213562373095?^n*n^(-1/2)*(e^(I*arg(I)))^n + O(1.414213562373095?^n*n^(-3/2))
 
     Check that there are no prohibited variable names::
 
         sage: var('n t u_')
         (n, t, u_)
-        sage: diagonal_asy(1/(1 - n - t - u_))
+        sage: diagonal_asymptotics_combinatorial(1/(1 - n - t - u_))
         0.866025403784439?/pi*27^n*n^(-1) + O(27^n*n^(-2))
 
     """
@@ -462,7 +490,7 @@ def diagonal_asy(
     R = PolynomialRing(QQ, vs, len(vs))
     H_sing = Ideal([R(H)] + [R(H.derivative(v)) for v in vs])
     if H_sing.dimension() < 0:
-        return _diagonal_asy_smooth(
+        return _diagonal_asymptotics_combinatorial_smooth(
             G,
             H,
             r=r,
@@ -674,7 +702,7 @@ def GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision):
     the asymptotic expansion for a given critical
     point of a rational combinatorial multivariate rational function.
 
-    Typically, this function is called as a subroutine of :func:`.diagonal_asy`.
+    Typically, this function is called as a subroutine of :func:`.diagonal_asymptotics_combinatorial`.
 
     INPUT:
 
@@ -799,7 +827,7 @@ def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
     rational function `F=G/H` admitting a finite number of critical points.
     Assumes the singular variety of `F` is smooth.
 
-    Typically, this function is called as a subroutine of :func:`._diagonal_asy_smooth`.
+    Typically, this function is called as a subroutine of :func:`._diagonal_asymptotics_combinatorial_smooth`.
 
     INPUT:
 
@@ -954,7 +982,7 @@ def _find_contributing_points_combinatorial(
     r"""Compute contributing points of a combinatorial multivariate
     rational function `F=G/H` admitting a finite number of critical points.
 
-    Typically, this function is called as a subroutine of :func:`.diagonal_asy`.
+    Typically, this function is called as a subroutine of :func:`.diagonal_asymptotics_combinatorial`.
 
     INPUT:
 
@@ -1380,7 +1408,7 @@ def CriticalPoints(F, r=None, linear_form=None, whitney_strat=None):
     r"""Compute critical points of a multivariate
     rational function `F=G/H` admitting a finite number of critical points.
 
-    Typically, this function is called as a subroutine of :func:`.diagonal_asy`.
+    Typically, this function is called as a subroutine of :func:`.diagonal_asymptotics_combinatorial`.
 
     INPUT:
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -23,7 +23,7 @@ from sage_acsv.kronecker import _kronecker_representation
 from sage_acsv.helpers import (
     ACSVException,
     is_contributing,
-    newton_series,
+    compute_newton_series,
     rational_function_reduce,
     compute_hessian,
     compute_implicit_hessian,
@@ -772,7 +772,7 @@ def _general_term_asymptotics(G, H, r, vs, cp, expansion_precision):
 
     # Find series expansion of function g given implicitly by
     # H(w_1, ..., w_{d-1}, g(w_1, ..., w_{d-1})) = 0 up to needed order
-    g = newton_series(H.subs({v: v + cp[v] for v in vs}), vs, N)
+    g = compute_newton_series(H.subs({v: v + cp[v] for v in vs}), vs, N)
     g = g.subs({v: v - cp[v] for v in vs}) + cp[vd]
 
     # Polar change of coordinates

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -150,7 +150,7 @@ def _diagonal_asymptotics_combinatorial_smooth(
     for _ in range(ACSVSettings.MAX_MIN_CRIT_RETRIES):
         try:
             # Find minimal critical points in Kronecker Representation
-            min_crit_pts = ContributingCombinatorialSmooth(
+            min_crit_pts = contributing_points_combinatorial_smooth(
                 G, H, vs, r=r, linear_form=linear_form
             )
             break
@@ -822,7 +822,7 @@ def GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision):
     return res
 
 
-def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
+def contributing_points_combinatorial_smooth(G, H, variables, r=None, linear_form=None):
     r"""Compute contributing points of a combinatorial multivariate
     rational function `F=G/H` admitting a finite number of critical points.
     Assumes the singular variety of `F` is smooth.
@@ -852,9 +852,9 @@ def ContributingCombinatorialSmooth(G, H, variables, r=None, linear_form=None):
 
     Examples::
 
-        sage: from sage_acsv import ContributingCombinatorialSmooth
+        sage: from sage_acsv import contributing_points_combinatorial_smooth
         sage: R.<x, y, w, lambda_, t, u_> = QQ[]
-        sage: pts = ContributingCombinatorialSmooth(
+        sage: pts = contributing_points_combinatorial_smooth(
         ....:     1,
         ....:     1 - w*(y + x + x^2*y + x*y^2),
         ....:     [w, x, y],

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -187,7 +187,7 @@ def _diagonal_asymptotics_combinatorial_smooth(
             [
                 term / (rd * n) ** (term_order)
                 for term_order, term in enumerate(
-                    GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision)
+                    _general_term_asymptotics(G, H, r, vs, cp, expansion_precision)
                 )
             ]
         )
@@ -608,7 +608,7 @@ def diagonal_asymptotics_combinatorial(
             expansion = sum(
                 term / (r[-1] * n) ** (term_order)
                 for term_order, term in enumerate(
-                    GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision)
+                    _general_term_asymptotics(G, H, r, vs, cp, expansion_precision)
                 )
             )
             Det = GetHessian(H, vs, r).determinant()
@@ -696,7 +696,7 @@ def diagonal_asymptotics_combinatorial(
     return result
 
 
-def GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision):
+def _general_term_asymptotics(G, H, r, vs, cp, expansion_precision):
     r"""
     Compute coefficients of general (not necessarily leading) terms of
     the asymptotic expansion for a given critical
@@ -721,11 +721,11 @@ def GeneralTermAsymptotics(G, H, r, vs, cp, expansion_precision):
 
     EXAMPLES::
 
-        sage: from sage_acsv import GeneralTermAsymptotics
+        sage: from sage_acsv import _general_term_asymptotics
         sage: R.<x, y, z> = QQ[]
-        sage: GeneralTermAsymptotics(1, 1 - x - y, [1, 1], [x, y], [1/2, 1/2], 5)
+        sage: _general_term_asymptotics(1, 1 - x - y, [1, 1], [x, y], [1/2, 1/2], 5)
         [2, -1/4, 1/64, 5/512, -21/16384]
-        sage: GeneralTermAsymptotics(1, 1 - x - y - z, [1, 1, 1], [x, y, z], [1/3, 1/3, 1/3], 4)
+        sage: _general_term_asymptotics(1, 1 - x - y - z, [1, 1, 1], [x, y, z], [1/3, 1/3, 1/3], 4)
         [3, -2/3, 2/27, 14/729]
     """
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -721,7 +721,7 @@ def _general_term_asymptotics(G, H, r, vs, cp, expansion_precision):
 
     EXAMPLES::
 
-        sage: from sage_acsv import _general_term_asymptotics
+        sage: from sage_acsv.asymptotics import _general_term_asymptotics
         sage: R.<x, y, z> = QQ[]
         sage: _general_term_asymptotics(1, 1 - x - y, [1, 1], [x, y], [1/2, 1/2], 5)
         [2, -1/4, 1/64, 5/512, -21/16384]

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -31,7 +31,7 @@ from sage_acsv.helpers import (
 )
 from sage_acsv.debug import Timer, acsv_logger
 from sage_acsv.settings import ACSVSettings
-from sage_acsv.whitney import WhitneyStrat
+from sage_acsv.whitney import whitney_stratification
 from sage_acsv.macaulay2 import PrimaryDecomposition, Saturate
 
 
@@ -1022,7 +1022,7 @@ def _find_contributing_points_combinatorial(
     pure_H = PolynomialRing(QQ, vs)
 
     if whitney_strat is None:
-        whitney_strat = WhitneyStrat(Ideal(pure_H(H)), pure_H)
+        whitney_strat = whitney_stratification(Ideal(pure_H(H)), pure_H)
     else:
         # Cast symbolic generators for provided stratification into the correct ring
         whitney_strat = [
@@ -1308,7 +1308,7 @@ def minimal_critical_points_combinatorial(
     pure_H = PolynomialRing(QQ, vs)
 
     if whitney_strat is None:
-        whitney_strat = WhitneyStrat(Ideal(pure_H(H)), pure_H)
+        whitney_strat = whitney_stratification(Ideal(pure_H(H)), pure_H)
     else:
         # Cast symbolic generators for provided stratification into the correct ring
         whitney_strat = [
@@ -1475,7 +1475,7 @@ def critical_points(F, r=None, linear_form=None, whitney_strat=None):
     pure_H = PolynomialRing(QQ, vs)
 
     if whitney_strat is None:
-        whitney_strat = WhitneyStrat(Ideal(pure_H(H)), pure_H)
+        whitney_strat = whitney_stratification(Ideal(pure_H(H)), pure_H)
     else:
         # Cast symbolic generators for provided stratification into the correct ring
         whitney_strat = [

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -32,7 +32,7 @@ from sage_acsv.helpers import (
 from sage_acsv.debug import Timer, acsv_logger
 from sage_acsv.settings import ACSVSettings
 from sage_acsv.whitney import whitney_stratification
-from sage_acsv.macaulay2 import PrimaryDecomposition, Saturate
+from sage_acsv.macaulay2 import compute_primary_decomposition, compute_saturation
 
 
 # we need to monkeypatch a function from the asymptotics module such that creating
@@ -1033,7 +1033,7 @@ def _find_contributing_points_combinatorial(
     critical_point_ideals = []
     for d, stratum in enumerate(whitney_strat):
         critical_point_ideals.append([])
-        for P in PrimaryDecomposition(stratum):
+        for P in compute_primary_decomposition(stratum):
             c = len(vs) - d
             P_ext = P.change_ring(expanded_R)
             M = matrix([[v * f.derivative(v) for v in vs] for f in P_ext.gens()] + [r])
@@ -1050,7 +1050,7 @@ def _find_contributing_points_combinatorial(
             )
             # Saturate cpid by lower dimension stratum, if d > 0
             if d > 0:
-                cpid = Saturate(cpid, whitney_strat[d - 1].change_ring(expanded_R))
+                cpid = compute_saturation(cpid, whitney_strat[d - 1].change_ring(expanded_R))
 
             critical_point_ideals[-1].append((P, cpid))
 
@@ -1319,7 +1319,7 @@ def minimal_critical_points_combinatorial(
     critical_points = []
     pos_minimals = []
     for d, stratum in enumerate(whitney_strat):
-        for P_comp in PrimaryDecomposition(stratum):
+        for P_comp in compute_primary_decomposition(stratum):
             c = len(vs) - d
             P_ext = P_comp.change_ring(expanded_R)
             M = matrix([[v * f.derivative(v) for v in vs] for f in P_ext.gens()] + [r])
@@ -1336,7 +1336,7 @@ def minimal_critical_points_combinatorial(
             )
             # Saturate cpid by lower dimension stratum, if d > 0
             if d > 0:
-                ideal = Saturate(ideal, whitney_strat[d - 1].change_ring(expanded_R))
+                ideal = compute_saturation(ideal, whitney_strat[d - 1].change_ring(expanded_R))
 
             if ideal.dimension() < 0:
                 continue
@@ -1485,7 +1485,7 @@ def critical_points(F, r=None, linear_form=None, whitney_strat=None):
 
     critical_points = []
     for d, stratum in enumerate(whitney_strat):
-        for P_comp in PrimaryDecomposition(stratum):
+        for P_comp in compute_primary_decomposition(stratum):
             c = len(vs) - d
             P_ext = P_comp.change_ring(expanded_R)
             M = matrix([[v * f.derivative(v) for v in vs] for f in P_ext.gens()] + [r])
@@ -1500,7 +1500,7 @@ def critical_points(F, r=None, linear_form=None, whitney_strat=None):
             )
             # Saturate cpid by lower dimension stratum, if d > 0
             if d > 0:
-                ideal = Saturate(ideal, whitney_strat[d - 1].change_ring(expanded_R))
+                ideal = compute_saturation(ideal, whitney_strat[d - 1].change_ring(expanded_R))
 
             if ideal.dimension() < 0:
                 continue

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -1239,7 +1239,12 @@ def ContributingCombinatorial(
     )
 
 
-def MinimalCriticalCombinatorial(F, r=None, linear_form=None, whitney_strat=None):
+def minimal_critical_points_combinatorial(
+        F,
+        r=None,
+        linear_form=None,
+        whitney_strat=None
+    ):
     r"""Compute nonzero minimal critical points of a combinatorial multivariate
     rational function `F=G/H` admitting a finite number of critical points.
 
@@ -1268,10 +1273,10 @@ def MinimalCriticalCombinatorial(F, r=None, linear_form=None, whitney_strat=None
 
     Examples::
 
-        sage: from sage_acsv import MinimalCriticalCombinatorial
+        sage: from sage_acsv import minimal_critical_points_combinatorial
         sage: var('x y')
         (x, y)
-        sage: pts = MinimalCriticalCombinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
+        sage: pts = minimal_critical_points_combinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
         sage: sorted(pts)
         [[3/4, 3/2], [1, 1]]
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -1239,12 +1239,24 @@ def contributing_points_combinatorial(
     )
 
 
+def MinimalCriticalCombinatorial(F, r=None, linear_form=None, whitney_strat=None):
+    from warnings import warn
+
+    warn(
+        "MinimalCriticalCombinatorial is deprecated and will be removed "
+        "in a future release. Please use minimal_critical_points_combinatorial "
+        "(same signature) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return minimal_critical_points_combinatorial(
+        F, r=r, linear_form=linear_form, whitney_strat=whitney_strat
+    )
+
+
 def minimal_critical_points_combinatorial(
-        F,
-        r=None,
-        linear_form=None,
-        whitney_strat=None
-    ):
+    F, r=None, linear_form=None, whitney_strat=None
+):
     r"""Compute nonzero minimal critical points of a combinatorial multivariate
     rational function `F=G/H` admitting a finite number of critical points.
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -1173,7 +1173,7 @@ def _find_contributing_points_combinatorial(
     return contributing_points
 
 
-def ContributingCombinatorial(
+def contributing_points_combinatorial(
     F,
     r=None,
     linear_form=None,
@@ -1208,10 +1208,10 @@ def ContributingCombinatorial(
 
     Examples::
 
-        sage: from sage_acsv import ContributingCombinatorial
+        sage: from sage_acsv import contributing_points_combinatorial
         sage: var('x y')
         (x, y)
-        sage: pts = ContributingCombinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
+        sage: pts = contributing_points_combinatorial(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
         sage: sorted(pts)
         [[3/4, 3/2]]
 

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -1404,7 +1404,7 @@ def MinimalCriticalCombinatorial(F, r=None, linear_form=None, whitney_strat=None
     return minimal_criticals
 
 
-def CriticalPoints(F, r=None, linear_form=None, whitney_strat=None):
+def critical_points(F, r=None, linear_form=None, whitney_strat=None):
     r"""Compute critical points of a multivariate
     rational function `F=G/H` admitting a finite number of critical points.
 
@@ -1435,10 +1435,10 @@ def CriticalPoints(F, r=None, linear_form=None, whitney_strat=None):
 
     Examples::
 
-        sage: from sage_acsv import CriticalPoints
+        sage: from sage_acsv import critical_points
         sage: var('x y')
         (x, y)
-        sage: pts = CriticalPoints(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
+        sage: pts = critical_points(1/((1-(2*x+y)/3)*(1-(3*x+y)/4)))
         sage: sorted(pts)
         [[2/3, 2], [3/4, 3/2], [1, 1]]
 

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -431,7 +431,7 @@ def get_expansion_terms(
 
     OUTPUT:
 
-    A list of :class:`.DecomposedTerm` objects (with attributes ``coefficient``, ``pi_factor``,
+    A list of :class:`.Term` objects (with attributes ``coefficient``, ``pi_factor``,
     ``base`` and ``power``), each representing a summand in the fully expanded expression.
 
     EXAMPLES::

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -436,24 +436,24 @@ def get_expansion_terms(
 
     EXAMPLES::
 
-        sage: from sage_acsv import diagonal_asy, get_expansion_terms
+        sage: from sage_acsv import diagonal_asymptotics_combinatorial, get_expansion_terms
         sage: var('x y z')
         (x, y, z)
-        sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2)
+        sage: res = diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[1,1], expansion_precision=2)
         sage: coefs = sorted(get_expansion_terms(res), reverse=True)
         sage: coefs
         [Term(coefficient=1, pi_factor=1/sqrt(pi), base=4, power=-1/2),
          Term(coefficient=-1/8, pi_factor=1/sqrt(pi), base=4, power=-3/2)]
-        sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="tuple")
+        sage: res = diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="tuple")
         sage: sorted(get_expansion_terms(res)) == sorted(coefs)
         True
-        sage: res = diagonal_asy(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="symbolic")
+        sage: res = diagonal_asymptotics_combinatorial(1/(1 - x - y), r=[1,1], expansion_precision=2, output_format="symbolic")
         sage: sorted(get_expansion_terms(res)) == sorted(coefs)
         True
 
     ::
 
-        sage: res = diagonal_asy(1/(1 - x^7))
+        sage: res = diagonal_asymptotics_combinatorial(1/(1 - x^7))
         sage: get_expansion_terms(res)
         [Term(coefficient=1/7, pi_factor=1, base=0.6234898018587335? + 0.7818314824680299?*I, power=0),
          Term(coefficient=1/7, pi_factor=1, base=0.6234898018587335? - 0.7818314824680299?*I, power=0),
@@ -465,7 +465,7 @@ def get_expansion_terms(
 
     ::
 
-        sage: res = diagonal_asy(1/(1 - x - y^2))
+        sage: res = diagonal_asymptotics_combinatorial(1/(1 - x - y^2))
         sage: coefs = get_expansion_terms(res); coefs
         [Term(coefficient=0.6123724356957945?, pi_factor=1/sqrt(pi), base=-2.598076211353316?, power=-1/2),
          Term(coefficient=0.6123724356957945?, pi_factor=1/sqrt(pi), base=2.598076211353316?, power=-1/2)]
@@ -477,7 +477,7 @@ def get_expansion_terms(
     ::
 
         sage: F2 = (1+x)*(1+y)/(1-z*x*y*(x+y+1/x+1/y))
-        sage: res = diagonal_asy(F2, expansion_precision=3)
+        sage: res = diagonal_asymptotics_combinatorial(F2, expansion_precision=3)
         sage: coefs = get_expansion_terms(res); coefs
         [Term(coefficient=4, pi_factor=1/pi, base=4, power=-1),
          Term(coefficient=1, pi_factor=1/pi, base=-4, power=-3),
@@ -486,13 +486,13 @@ def get_expansion_terms(
 
     ::
 
-        sage: res = diagonal_asy(3/(1 - x))
+        sage: res = diagonal_asymptotics_combinatorial(3/(1 - x))
         sage: get_expansion_terms(res)
         [Term(coefficient=3, pi_factor=1, base=1, power=0)]
 
     ::
 
-        sage: res = diagonal_asy((x - y)/(1 - x - y))
+        sage: res = diagonal_asymptotics_combinatorial((x - y)/(1 - x - y))
         sage: get_expansion_terms(res)
         []
 

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -191,7 +191,7 @@ def compute_hessian(H, variables, r, critical_point=None):
     return hessian
 
 
-def newton_series(phi, variables, series_precision):
+def compute_newton_series(phi, variables, series_precision):
     r"""Computes the series expansion of an implicitly defined function.
 
     The function `g(x)` for which a series expansion is computed satisfies
@@ -213,9 +213,9 @@ def newton_series(phi, variables, series_precision):
 
     EXAMPLES::
 
-        sage: from sage_acsv.helpers import newton_series
+        sage: from sage_acsv.helpers import compute_newton_series
         sage: R.<x, T> = QQ[]
-        sage: newton_series(x*T^2 - T + 1, [x, T], 7)
+        sage: compute_newton_series(x*T^2 - T + 1, [x, T], 7)
         132*x^6 + 42*x^5 + 14*x^4 + 5*x^3 + 2*x^2 + x + 1
 
     """

--- a/sage_acsv/helpers.py
+++ b/sage_acsv/helpers.py
@@ -70,7 +70,7 @@ def collapse_zero_part(algebraic_number: AlgebraicNumber) -> AlgebraicNumber:
     return algebraic_number
 
 
-def RationalFunctionReduce(G, H):
+def rational_function_reduce(G, H):
     r"""Reduction of G and H by dividing out their GCD.
 
     INPUT:
@@ -85,7 +85,7 @@ def RationalFunctionReduce(G, H):
     return G / g, H / g
 
 
-def GenerateLinearForm(system, vsT, u_, linear_form=None):
+def generate_linear_form(system, vsT, u_, linear_form=None):
     r"""Generate a linear form of the input system.
 
     This is an integer linear combination of the variables that
@@ -120,7 +120,7 @@ def GenerateLinearForm(system, vsT, u_, linear_form=None):
     )
 
 
-def GetHessian(H, variables, r, critical_point=None):
+def compute_hessian(H, variables, r, critical_point=None):
     r"""Computes the Hessian of a given map.
 
     The map underlying `Hess` is defined as
@@ -191,7 +191,7 @@ def GetHessian(H, variables, r, critical_point=None):
     return hessian
 
 
-def NewtonSeries(phi, variables, series_precision):
+def newton_series(phi, variables, series_precision):
     r"""Computes the series expansion of an implicitly defined function.
 
     The function `g(x)` for which a series expansion is computed satisfies
@@ -213,9 +213,9 @@ def NewtonSeries(phi, variables, series_precision):
 
     EXAMPLES::
 
-        sage: from sage_acsv.helpers import NewtonSeries
+        sage: from sage_acsv.helpers import newton_series
         sage: R.<x, T> = QQ[]
-        sage: NewtonSeries(x*T^2 - T + 1, [x, T], 7)
+        sage: newton_series(x*T^2 - T + 1, [x, T], 7)
         132*x^6 + 42*x^5 + 14*x^4 + 5*x^3 + 2*x^2 + x + 1
 
     """
@@ -243,7 +243,7 @@ def NewtonSeries(phi, variables, series_precision):
     return NewtonRecur(Mod(phi, series_precision), series_precision)[0]
 
 
-def ImplicitHessian(Hs, vs, r, subs):
+def compute_implicit_hessian(Hs, vs, r, subs):
     r"""Compute the Hessian of an implicitly defined function.
 
     Given a transverse intersection point `w` in `H_1(w),\dots,H_s(w)=0`, we can parametrize `V(H_1,\dots,H_s)`
@@ -265,13 +265,13 @@ def ImplicitHessian(Hs, vs, r, subs):
 
     EXAMPLES::
 
-        sage: from sage_acsv.helpers import ImplicitHessian
+        sage: from sage_acsv.helpers import compute_implicit_hessian
         sage: R.<x,y,z,w> = PolynomialRing(QQ,4)
         sage: Hs = [
         ....:     z^2+z*w+x*y-4,
         ....:     w^3+z*x-y
         ....: ]
-        sage: ImplicitHessian(Hs, [x,y,z,w], [1,1,1,1], {x:1,y:1,z:1,w:1})
+        sage: compute_implicit_hessian(Hs, [x,y,z,w], [1,1,1,1], {x:1,y:1,z:1,w:1})
         [21/32     0]
         [    0   7/8]
     """
@@ -347,7 +347,7 @@ def ImplicitHessian(Hs, vs, r, subs):
     return Hess
 
 
-def IsContributing(vs, pt, r, factors, c):
+def is_contributing(vs, pt, r, factors, c):
     r"""Determines if minimal critical point `pt` where singular variety has transverse square-free factorization
     is contributing; that is, whether `r` is in the interior
     of the scaled log-normal cone of `factors` at `pt`
@@ -366,11 +366,11 @@ def IsContributing(vs, pt, r, factors, c):
 
     EXAMPLES::
 
-        sage: from sage_acsv.helpers import IsContributing
+        sage: from sage_acsv.helpers import is_contributing
         sage: R.<x,y> = PolynomialRing(QQ, 2)
-        sage: IsContributing([x,y], [1,1], [17/24, 7/24], [1-(2*x+y)/3,1-(3*x+y)/4], 2)
+        sage: is_contributing([x,y], [1,1], [17/24, 7/24], [1-(2*x+y)/3,1-(3*x+y)/4], 2)
         True
-        sage: IsContributing([x,y], [1,1], [1, 1], [1-(2*x+y)/3,1-(3*x+y)/4], 2)
+        sage: is_contributing([x,y], [1,1], [1, 1], [1-(2*x+y)/3,1-(3*x+y)/4], 2)
         False
 
     """

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -198,7 +198,7 @@ def kronecker_representation(system, vs, linear_form=None):
     ``z_i = Q_i(u)/P'(u)`` for ``u`` ranging over the roots of ``P``.
 
     Examples::
-        sage: from sage_acsv.kronecker import kronecker
+        sage: from sage_acsv.kronecker import kronecker_representation
         sage: var('x,y')
         (x, y)
         sage: kronecker_representation([x**3+y**3-10, y**2-2], [x,y], x+y)

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -30,10 +30,10 @@ def _kronecker_representation_sage(system, u_, vs, linear_form=None):
 
     Examples::
 
-        sage: from sage_acsv.kronecker import kronecker
+        sage: from sage_acsv.kronecker import kronecker_representation
         sage: var('x, y')
         (x, y)
-        sage: kronecker(
+        sage: kronecker_representation(
         ....:     [x**3+y**3-10, y**2-2],
         ....:     [x, y],
         ....:     linear_form=x + y
@@ -170,8 +170,19 @@ def _kronecker_representation(system, u_, vs, linear_form=None):
         return _kronecker_representation_msolve(system, u_, vs)
     return _kronecker_representation_sage(system, u_, vs, linear_form=linear_form)
 
-
 def kronecker(system, vs, linear_form=None):
+    from warnings import warn
+    warn(
+        "The kronecker function has been deprecated and will "
+        "be removed in a future version. Please use the "
+        "kronecker_representation function (same signature) instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return kronecker_representation(system, vs, linear_form=linear_form)
+
+
+def kronecker_representation(system, vs, linear_form=None):
     r"""Computes the Kronecker Representation of a system of polynomials
 
     INPUT:
@@ -190,7 +201,7 @@ def kronecker(system, vs, linear_form=None):
         sage: from sage_acsv.kronecker import kronecker
         sage: var('x,y')
         (x, y)
-        sage: kronecker([x**3+y**3-10, y**2-2], [x,y], x+y)
+        sage: kronecker_representation([x**3+y**3-10, y**2-2], [x,y], x+y)
         (u_^6 - 6*u_^4 - 20*u_^3 + 36*u_^2 - 120*u_ + 100,
          [60*u_^3 - 72*u_^2 + 360*u_ - 600, 12*u_^4 - 72*u_^2 + 240*u_])
     """

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -4,7 +4,7 @@ from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from sage_acsv.helpers import ACSVException, generate_linear_form
 from sage_acsv.debug import acsv_logger
 from sage_acsv.msolve import get_parametrization
-from sage_acsv.macaulay2 import GroebnerBasis, Radical
+from sage_acsv.macaulay2 import compute_groebner_basis, compute_radical
 from sage_acsv.settings import ACSVSettings
 
 
@@ -58,7 +58,7 @@ def _kronecker_representation_sage(system, u_, vs, linear_form=None):
     # Compute Grobner basis for ordered system of polynomials
     ideal = MPolynomialIdeal(rabinowitsch_R, rabinowitsch_system)
     try:
-        ideal = MPolynomialIdeal(rabinowitsch_R, GroebnerBasis(ideal))
+        ideal = MPolynomialIdeal(rabinowitsch_R, compute_groebner_basis(ideal))
     except Exception:
         raise ACSVException(
             "Trouble computing Groebner basis. System may be too large."
@@ -69,7 +69,7 @@ def _kronecker_representation_sage(system, u_, vs, linear_form=None):
             f"Ideal {ideal} is not 0-dimensional. Cannot compute Kronecker representation."
         )
 
-    ideal = Radical(ideal)
+    ideal = compute_radical(ideal)
     gb = ideal.transformed_basis("fglm")
 
     rabinowitsch_R = rabinowitsch_R.change_ring(order="lex")

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -1,7 +1,7 @@
 from sage.all import PolynomialRing, QQ, gcd
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 
-from sage_acsv.helpers import ACSVException, GenerateLinearForm
+from sage_acsv.helpers import ACSVException, generate_linear_form
 from sage_acsv.debug import acsv_logger
 from sage_acsv.msolve import get_parametrization
 from sage_acsv.macaulay2 import GroebnerBasis, Radical
@@ -43,7 +43,7 @@ def _kronecker_representation_sage(system, u_, vs, linear_form=None):
     """
 
     # Generate a linear form
-    linear_form = GenerateLinearForm(system, vs, u_, linear_form)
+    linear_form = generate_linear_form(system, vs, u_, linear_form)
 
     expanded_R = u_.parent()
 

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -12,7 +12,7 @@ def _kronecker_representation_sage(system, u_, vs, linear_form=None):
     r"""Computes the Kronecker Representation of a system of polynomials.
 
     This method is intended for internal use and requires a consistent
-    setup of parameters. Use the :func:`.kronecker` wrapper function
+    setup of parameters. Use the :func:`.kronecker_representation` wrapper function
     to avoid doing the setup yourself.
 
     INPUT:

--- a/sage_acsv/macaulay2.py
+++ b/sage_acsv/macaulay2.py
@@ -13,7 +13,7 @@ def _construct_m2_morphims(ideal):
     return mor, inv
 
 
-def PrimaryDecomposition(ideal):
+def compute_primary_decomposition(ideal):
     """Return the primary decomposition of an ideal.
 
     If a Macaulay2 interface is provided, it will be used instead
@@ -31,7 +31,7 @@ def PrimaryDecomposition(ideal):
     return ideal.primary_decomposition()
 
 
-def Saturate(ideal_I, ideal_J):
+def compute_saturation(ideal_I, ideal_J):
     """Return the saturation of ideal I with respect to ideal J.
 
     INPUT:
@@ -42,7 +42,7 @@ def Saturate(ideal_I, ideal_J):
     return ideal_I.saturation(ideal_J)[0]
 
 
-def GroebnerBasis(ideal):
+def compute_groebner_basis(ideal):
     """Return a Groebner Basis of an ideal.
 
     If a Macaulay2 interface is provided, it will be used instead
@@ -62,7 +62,7 @@ def GroebnerBasis(ideal):
     return ideal.groebner_basis()
 
 
-def Radical(ideal):
+def compute_radical(ideal):
     """Return the radical of an ideal.
 
     If a Macaulay2 interface is provided, it will be used instead

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -26,13 +26,13 @@ class OutputFormat(Enum):
 
 class KroneckerBackend(Enum):
     """Options for computing Kronecker representations determined by
-    :func:`.ContributingCombinatorial`, :func:`.MinimalCriticalCombinatorial`, and
+    :func:`.ContributingCombinatorial`, :func:`.minimal_critical_points_combinatorial`, and
     :func:`.critical_points`.
 
     See also:
 
     - :func:`.ContributingCombinatorial`
-    - :func:`.MinimalCriticalCombinatorial`
+    - :func:`.minimal_critical_points_combinatorial`
     - :func:`.critical_points`
     - :class:`.ACSVSettings`
 

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -44,13 +44,13 @@ class KroneckerBackend(Enum):
 
 class GroebnerBackend(Enum):
     """Options for computing Groebner Bases and related ideal functions
-    :func:`.GroebnerBasis`, :func:`.PrimaryDecomposition`, and :func:`.critical_points`.
+    :func:`.compute_groebner_basis`, :func:`.compute_primary_decomposition`, and :func:`.critical_points`.
 
     See also:
 
-    - :func:`.GroebnerBasis`
-    - :func:`.PrimaryDecomposition`
-    - :func:`.Radical`
+    - :func:`.compute_groebner_basis`
+    - :func:`.compute_primary_decomposition`
+    - :func:`.compute_radical`
     - :class:`.ACSVSettings`
 
     """
@@ -180,7 +180,7 @@ class ACSVSettings:
         cls, backend: GroebnerBackend | str | None
     ) -> None:
         """Set the preferred method for performing Groebner Bases and related computations,
-        including :func:`.GroebnerBasis`, :func:`.PrimaryDecomposition`, and :func:`.Radical`
+        including :func:`.compute_groebner_basis`, :func:`.compute_primary_decomposition`, and :func:`.compute_radical`.
 
         Will default to singular.
 

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -26,12 +26,12 @@ class OutputFormat(Enum):
 
 class KroneckerBackend(Enum):
     """Options for computing Kronecker representations determined by
-    :func:`.ContributingCombinatorial`, :func:`.minimal_critical_points_combinatorial`, and
+    :func:`.contributing_points_combinatorial`, :func:`.minimal_critical_points_combinatorial`, and
     :func:`.critical_points`.
 
     See also:
 
-    - :func:`.ContributingCombinatorial`
+    - :func:`.contributing_points_combinatorial`
     - :func:`.minimal_critical_points_combinatorial`
     - :func:`.critical_points`
     - :class:`.ACSVSettings`

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -27,13 +27,13 @@ class OutputFormat(Enum):
 class KroneckerBackend(Enum):
     """Options for computing Kronecker representations determined by
     :func:`.ContributingCombinatorial`, :func:`.MinimalCriticalCombinatorial`, and
-    :func:`.CriticalPoints`.
+    :func:`.critical_points`.
 
     See also:
 
     - :func:`.ContributingCombinatorial`
     - :func:`.MinimalCriticalCombinatorial`
-    - :func:`.CriticalPoints`
+    - :func:`.critical_points`
     - :class:`.ACSVSettings`
 
     """
@@ -44,7 +44,7 @@ class KroneckerBackend(Enum):
 
 class GroebnerBackend(Enum):
     """Options for computing Groebner Bases and related ideal functions
-    :func:`.GroebnerBasis`, :func:`.PrimaryDecomposition`, and :func:`.CriticalPoints`.
+    :func:`.GroebnerBasis`, :func:`.PrimaryDecomposition`, and :func:`.critical_points`.
 
     See also:
 

--- a/sage_acsv/settings.py
+++ b/sage_acsv/settings.py
@@ -10,11 +10,11 @@ from sage.all import Macaulay2
 
 class OutputFormat(Enum):
     """Output options for displaying the asymptotic behavior determined
-    by :func:`.diagonal_asy`.
+    by :func:`.diagonal_asymptotics_combinatorial`.
 
     See also:
 
-    - :func:`.diagonal_asy`
+    - :func:`.diagonal_asymptotics_combinatorial`
     - :class:`.ACSVSettings`
 
     """

--- a/sage_acsv/whitney.py
+++ b/sage_acsv/whitney.py
@@ -4,7 +4,7 @@ from sage.all import Combinations, matrix
 from sage_acsv.macaulay2 import compute_primary_decomposition, compute_groebner_basis, compute_saturation, compute_radical
 
 
-def Con(X, P, RZ):
+def conormal_ideal(X, P, RZ):
     r"""Compute the ideal associated with the map sending `X` to its conormal space.
 
     The map is also denoted as `\operatorname{Con}(X)`.
@@ -21,7 +21,7 @@ def Con(X, P, RZ):
     return compute_saturation(X.defining_ideal().change_ring(RZ) + JacZ, Jac.change_ring(RZ))
 
 
-def Decompose(Y, X, P, R, RZ):
+def decompose_variety(Y, X, P, R, RZ):
     r"""Given varieties `X` and `Y`, return the points in `Y` that fail
     Whitney's condition `B` with respect to `X`.
     """
@@ -29,7 +29,7 @@ def Decompose(Y, X, P, R, RZ):
     Ys = [P.subscheme(1) for _ in range(d + 1)]
     Ys[-1] = Y
 
-    J = Con(X, P, RZ) + Y.defining_ideal().change_ring(RZ)
+    J = conormal_ideal(X, P, RZ) + Y.defining_ideal().change_ring(RZ)
     J = Ideal(compute_groebner_basis(J))
     for IQ in compute_primary_decomposition(J):
         K = IQ.elimination_ideal(
@@ -57,7 +57,7 @@ def merge_stratifications(Xs, Ys):
     return res
 
 
-def WhitneyStratProjective(X, P):
+def whitney_stratification_projective(X, P):
     r"""
     Computes a Whitney stratification of projective variety X in the ring P
     """
@@ -83,8 +83,8 @@ def WhitneyStratProjective(X, P):
         Xd = Xs[d]
         if Xd.dimension() < d:
             continue
-        Xs = merge_stratifications(Xs, Decompose(Xd, X, P, R, RZ))
-        Xs = merge_stratifications(Xs, WhitneyStratProjective(Xd, P))
+        Xs = merge_stratifications(Xs, decompose_variety(Xd, X, P, R, RZ))
+        Xs = merge_stratifications(Xs, whitney_stratification_projective(Xd, P))
 
     return Xs
 
@@ -140,7 +140,7 @@ def whitney_stratification(IX, R):
 
     z0 = vsP[-1]
     R_hom = z0.parent()
-    proj_strat = WhitneyStratProjective(
+    proj_strat = whitney_stratification_projective(
         P.subscheme(IX.change_ring(R_hom).homogenize(z0)), P
     )
 

--- a/sage_acsv/whitney.py
+++ b/sage_acsv/whitney.py
@@ -59,7 +59,7 @@ def merge_stratifications(Xs, Ys):
 
 def WhitneyStratProjective(X, P):
     r"""
-    Computes a WhitneyStratification of projective variety X in the ring P
+    Computes a Whitney stratification of projective variety X in the ring P
     """
     X = P.subscheme(Radical(X.defining_ideal()))
     vs = P.gens()
@@ -89,7 +89,7 @@ def WhitneyStratProjective(X, P):
     return Xs
 
 
-def WhitneyStrat(IX, R):
+def whitney_stratification(IX, R):
     r"""Computes the Whitney Stratification of a pure-dimensional algebraic variety.
 
     Uses an algorithm developed by Helmer and Nanda (2022).
@@ -106,9 +106,9 @@ def WhitneyStrat(IX, R):
 
     EXAMPLES::
 
-        sage: from sage_acsv.whitney import WhitneyStrat
+        sage: from sage_acsv.whitney import whitney_stratification
         sage: R.<x,y,z> = PolynomialRing(QQ, 3)
-        sage: WhitneyStrat(Ideal(y^2+x^3-y^2*z^2), R)
+        sage: whitney_stratification(Ideal(y^2+x^3-y^2*z^2), R)
         [Ideal (y, x, z^2 - 1) of Multivariate Polynomial Ring in x, y, z over Rational Field,
          Ideal (y, x) of Multivariate Polynomial Ring in x, y, z over Rational Field,
          Ideal (y^2*z^2 - x^3 - y^2) of Multivariate Polynomial Ring in x, y, z over Rational Field]

--- a/sage_acsv/whitney.py
+++ b/sage_acsv/whitney.py
@@ -1,7 +1,7 @@
 from sage.all import Ideal, PolynomialRing, ProjectiveSpace, QQ
 from sage.all import Combinations, matrix
 
-from sage_acsv.macaulay2 import PrimaryDecomposition, GroebnerBasis, Saturate, Radical
+from sage_acsv.macaulay2 import compute_primary_decomposition, compute_groebner_basis, compute_saturation, compute_radical
 
 
 def Con(X, P, RZ):
@@ -13,12 +13,12 @@ def Con(X, P, RZ):
     vzs = tuple(v for v in RZ.gens() if v not in vs)
     c = X.codimension()
 
-    X = P.subscheme(Radical(X.defining_ideal()))
+    X = P.subscheme(compute_radical(X.defining_ideal()))
     M = X.Jacobian_matrix()
     Jac = X.Jacobian()
     JacZ = Ideal(matrix([list(vzs)] + list(M)).minors(c + 1))
 
-    return Saturate(X.defining_ideal().change_ring(RZ) + JacZ, Jac.change_ring(RZ))
+    return compute_saturation(X.defining_ideal().change_ring(RZ) + JacZ, Jac.change_ring(RZ))
 
 
 def Decompose(Y, X, P, R, RZ):
@@ -30,8 +30,8 @@ def Decompose(Y, X, P, R, RZ):
     Ys[-1] = Y
 
     J = Con(X, P, RZ) + Y.defining_ideal().change_ring(RZ)
-    J = Ideal(GroebnerBasis(J))
-    for IQ in PrimaryDecomposition(J):
+    J = Ideal(compute_groebner_basis(J))
+    for IQ in compute_primary_decomposition(J):
         K = IQ.elimination_ideal(
             [v for v in RZ.gens() if v not in R.gens()]
         ).change_ring(R)
@@ -61,7 +61,7 @@ def WhitneyStratProjective(X, P):
     r"""
     Computes a Whitney stratification of projective variety X in the ring P
     """
-    X = P.subscheme(Radical(X.defining_ideal()))
+    X = P.subscheme(compute_radical(X.defining_ideal()))
     vs = P.gens()
     k = X.dimension()
 
@@ -74,7 +74,7 @@ def WhitneyStratProjective(X, P):
     X_sing = X.intersection(P.subscheme(X.Jacobian()))
     mu = X_sing.dimension()
 
-    for IZ in PrimaryDecomposition(X_sing.defining_ideal()):
+    for IZ in compute_primary_decomposition(X_sing.defining_ideal()):
         Z = P.subscheme(IZ)
         i = Z.dimension()
         Xs[i] = Xs[i].union(Z)
@@ -131,9 +131,9 @@ def whitney_stratification(IX, R):
             strat[-1] = Ideal(IX.gens())
             for k in reversed(range(1, d)):
                 Jac = matrix([[f.derivative(v) for v in vs] for f in strat[k].gens()])
-                sing = Radical(Ideal(Jac.minors(d - k) + strat[k].gens()))
+                sing = compute_radical(Ideal(Jac.minors(d - k) + strat[k].gens()))
                 for i in range(max(sing.dimension(), 0), k):
-                    strat[i] = Radical(sing.intersection(strat[i]))
+                    strat[i] = compute_radical(sing.intersection(strat[i]))
             return strat
 
     P, vsP = ProjectiveSpace(QQ, len(vs), list(vs) + ["z0"]).objgens()
@@ -146,9 +146,9 @@ def whitney_stratification(IX, R):
 
     strat = [Ideal(R(1)) for _ in range(len(proj_strat))]
     for stratum in proj_strat:
-        for Id in PrimaryDecomposition(stratum.defining_ideal()):
+        for Id in compute_primary_decomposition(stratum.defining_ideal()):
             newId = Id.subs({z0: 1}).change_ring(R)
             for k in range(newId.dimension(), len(strat)):
-                strat[k] = Radical(strat[k].intersection(newId))
+                strat[k] = compute_radical(strat[k].intersection(newId))
 
     return strat


### PR DESCRIPTION
This PR renames *a lot* of functions in our package to make sure that they follow a more consistent naming scheme.

Deprecation warnings are also introduced for core interface functions that appeared in the arXiv paper on the smooth case (in particular, `diagonal_asy` and `kronecker`).