### PR TITLE
Fix a problem with asymptotic formula

### DIFF
--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -622,9 +622,9 @@ def diagonal_asymptotics_combinatorial(
             # For non-complete intersections, we must compute the parametrized Hessian matrix
             if s != d:
                 Qw = compute_implicit_hessian(factors, vs, r, subs=subs_dict)
-                expansion = SR(G.subs(subs_dict) / abs(Gamma.determinant()) / unit)
+                expansion = SR(prod([v for v in vs[: d - s]]).subs(subs_dict) * G.subs(subs_dict) / abs(Gamma.determinant()) / unit)
                 B = SR(
-                    prod([v for v in vs[: d - s]]).subs(subs_dict)
+                    1
                     / (r[-1] * Qw).determinant()
                     / 2 ** (d - s)
                 )

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -537,7 +537,10 @@ def diagonal_asymptotics_combinatorial(
         return
 
     asm_quantities = []
+    # Store copy of vs and r in case order changes due to parametrization
+    vs_copy, r_copy = copy(vs), copy(r)
     for cp in min_crit_pts:
+        vs, r = copy(vs_copy), copy(r_copy)
         # Step 1: Determine if pt is a transverse multiple point of H, and compute the factorization
         # for now, we'll just try to factor it in the polynomial ring
         R = PolynomialRing(QQbar, len(vs), vs)

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -625,7 +625,7 @@ def diagonal_asymptotics_combinatorial(
                 expansion = SR(prod([v for v in vs[: d - s]]).subs(subs_dict) * G.subs(subs_dict) / abs(Gamma.determinant()) / unit)
                 B = SR(
                     1
-                    / (r[-1] * Qw).determinant()
+                    / Qw.determinant()
                     / 2 ** (d - s)
                 )
             else:

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -622,7 +622,7 @@ def diagonal_asymptotics_combinatorial(
             # For non-complete intersections, we must compute the parametrized Hessian matrix
             if s != d:
                 Qw = compute_implicit_hessian(factors, vs, r, subs=subs_dict)
-                expansion = SR(prod([v for v in vs[: d - s]]).subs(subs_dict) * G.subs(subs_dict) / abs(Gamma.determinant()) / unit)
+                expansion = SR(abs(prod([v for v in vs[: d - s]]).subs(subs_dict)) * G.subs(subs_dict) / abs(Gamma.determinant()) / unit)
                 B = SR(
                     1
                     / Qw.determinant()


### PR DESCRIPTION
There is an issue with computing asymptotics in the non-complete intersection case. It wasn't covered by the tests previously because we were using the smooth asymptotics formula when the critical point was on the highest dimensional stratum.

I was incorrectly taking the square root of the product of the points.