### PR TITLE
Issue deprecation warnings via module logger

### DIFF
--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -636,7 +636,7 @@ def diagonal_asymptotics_combinatorial(
             break
         except Exception as e:
             if isinstance(e, ACSVException) and e.retry:
-                acsv_logger.warning(
+                acsv_logger.info(
                     "Randomly generated linear form was not suitable, "
                     f"encountered error: {e}\nRetrying..."
                 )

--- a/sage_acsv/asymptotics.py
+++ b/sage_acsv/asymptotics.py
@@ -373,13 +373,9 @@ def diagonal_asy(
     whitney_strat=None,
     as_symbolic=False,
 ):
-    from warnings import warn
-
-    warn(
+    acsv_logger.warning(
         "diagonal_asy is deprecated and will be removed in a future release. "
         "Please use diagonal_asymptotics_combinatorial (same signature) instead.",
-        DeprecationWarning,
-        stacklevel=2,
     )
     return diagonal_asymptotics_combinatorial(
         F,
@@ -1358,14 +1354,10 @@ def contributing_points_combinatorial(
 
 
 def MinimalCriticalCombinatorial(F, r=None, linear_form=None, whitney_strat=None):
-    from warnings import warn
-
-    warn(
+    acsv_logger.warning(
         "MinimalCriticalCombinatorial is deprecated and will be removed "
         "in a future release. Please use minimal_critical_points_combinatorial "
         "(same signature) instead.",
-        DeprecationWarning,
-        stacklevel=2,
     )
     return minimal_critical_points_combinatorial(
         F, r=r, linear_form=linear_form, whitney_strat=whitney_strat

--- a/sage_acsv/kronecker.py
+++ b/sage_acsv/kronecker.py
@@ -171,13 +171,10 @@ def _kronecker_representation(system, u_, vs, linear_form=None):
     return _kronecker_representation_sage(system, u_, vs, linear_form=linear_form)
 
 def kronecker(system, vs, linear_form=None):
-    from warnings import warn
-    warn(
+    acsv_logger.warning(
         "The kronecker function has been deprecated and will "
         "be removed in a future version. Please use the "
         "kronecker_representation function (same signature) instead.",
-        DeprecationWarning,
-        stacklevel=2,
     )
     return kronecker_representation(system, vs, linear_form=linear_form)
 


### PR DESCRIPTION
This moves the system used to issue deprecation warnings from `warnings.warn` (which might have needed some more care to setup correctly) to our already setup and running `acsv_logger`.

This resolves a problem where the logger output was not printed properly.